### PR TITLE
Removing scannotation. #42

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -50,11 +50,6 @@
 			<version>2.5.2</version>
 		</dependency>
 		<dependency>
-			<groupId>net.sf.scannotation</groupId>
-			<artifactId>scannotation</artifactId>
-			<version>1.0.2</version>
-		</dependency>
-		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<version>1.3.1</version>


### PR DESCRIPTION
Closes #42. We don't need scannotations, since CDI will scan classpath.
