### PR TITLE
Upgrading slf4j to 1.7.x. #42

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -27,12 +27,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.6.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.1</version>
+			<version>1.7.5</version>
 		</dependency>
 		<dependency>
 			<groupId>net.vidageek</groupId>
@@ -109,7 +104,7 @@
 		<dependency>
 		    <groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-simple</artifactId>
-		    <version>1.6.4</version>
+		    <version>1.7.5</version>
 		    <scope>test</scope>
 		</dependency>                        				
 		<!-- [/cdi] -->


### PR DESCRIPTION
Closes #42. This pull request allow us to use varargs when call logger.info/debug, and so on.
