### PR TITLE
linkTo can be managed by CDI too lazy as possible

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/ControllerHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/ControllerHandler.java
@@ -21,7 +21,6 @@ package br.com.caelum.vraptor.ioc;
 
 import java.util.List;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -35,7 +34,6 @@ import br.com.caelum.vraptor.core.ControllerQualifier;
 import br.com.caelum.vraptor.http.route.Route;
 import br.com.caelum.vraptor.http.route.Router;
 import br.com.caelum.vraptor.http.route.RoutesParser;
-import br.com.caelum.vraptor.view.LinkToHandler;
 
 @ApplicationScoped
 public class ControllerHandler{
@@ -55,11 +53,6 @@ public class ControllerHandler{
 		this.router = router;
 		this.parser = parser;
 		this.context = context;
-	}
-
-	@PostConstruct
-	public void configureLinkToHandler() {
-		new LinkToHandler(context, router).start();
 	}
 
 	public void handle(@Observes @ControllerQualifier BeanClass annotatedType) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/LinkToHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/LinkToHandler.java
@@ -22,6 +22,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
 import javax.servlet.ServletContext;
 
 import net.vidageek.mirror.dsl.Mirror;
@@ -40,21 +44,28 @@ import com.google.common.collect.ForwardingMap;
  * @since 3.4.0
  *
  */
+@Named("linkTo")
+@ApplicationScoped
 public class LinkToHandler extends ForwardingMap<Class<?>, Object> {
 
 	private static final Logger logger = LoggerFactory.getLogger(LinkToHandler.class);
 
-	private final ServletContext context;
-	private final Router router;
+	private ServletContext context;
+	private Router router;
 
+	@Deprecated // CDI eyes only
+	public LinkToHandler() {
+	}
+	
+	@Inject
 	public LinkToHandler(ServletContext context, Router router) {
 		this.context = context;
 		this.router = router;
 	}
 
+	@PostConstruct
 	public void start() {
 		logger.info("Registering linkTo component");
-		context.setAttribute("linkTo", this);
 	}
 
 	@Override


### PR DESCRIPTION
CDI can managed LinkToHandler as application scoped component. With this, instantiation will be too lazy as possible. I've tested in musicjungle and works fine.
