### PR TITLE
Fixes auth interceptor on MusicJungle

### DIFF
--- a/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/interceptor/AuthorizationInterceptor.java
+++ b/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/interceptor/AuthorizationInterceptor.java
@@ -65,7 +65,8 @@ public class AuthorizationInterceptor {
 		}
 
 		/**
-		 * You can use the result even in interceptors.
+		 * You can use the result even in interceptors, but you can't use Validator.onError* methods because
+		 * they throw ValidationException.
 		 */
 		if (current == null) {
 			// remember added parameters will survive one more request, when there is a redirect


### PR DESCRIPTION
During my tests on music-jungle when I access an URL not permitted I get this error:

> java.lang.IllegalStateException: Cannot forward after response has been committed

When interceptor uses **@BeforeCall** it can't stop the flow of request when the user isn't logged in, so it's necessary to use **@AroundCall** instead.
