### PR TITLE
XStream and Gson will scanned only if present

### DIFF
--- a/vraptor-core/src/main/resources/META-INF/beans.xml
+++ b/vraptor-core/src/main/resources/META-INF/beans.xml
@@ -36,19 +36,19 @@
 		</exclude>
 
 		<exclude name="br.com.caelum.vraptor.serialization.xstream.*">
-			<if-class-available name="com.thoughtworks.xstream.XStream"/>
+			<if-class-not-available name="com.thoughtworks.xstream.XStream"/>
 		</exclude>
 
 		<exclude name="br.com.caelum.vraptor.deserialization.xstream.*">
-			<if-class-available name="com.thoughtworks.xstream.XStream"/>
+			<if-class-not-available name="com.thoughtworks.xstream.XStream"/>
 		</exclude>
 
 		<exclude name="br.com.caelum.vraptor.serialization.gson.*">
-			<if-class-available name="com.google.gson.Gson"/>
+			<if-class-not-available name="com.google.gson.Gson"/>
 		</exclude>
 
 		<exclude name="br.com.caelum.vraptor.deserialization.gson.*">
-			<if-class-available name="com.google.gson.Gson"/>
+			<if-class-not-available name="com.google.gson.Gson"/>
 		</exclude>
 	</scan>
 	


### PR DESCRIPTION
This pull request allow users to get better performance if application don't use serialization and deserialization. With this, serialization object will not loaded.
