### PR TITLE
Changing signature to avoid confusion with another implementations

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorInstantiator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorInstantiator.java
@@ -41,7 +41,7 @@ import br.com.caelum.vraptor.converter.ConversionException;
 import br.com.caelum.vraptor.core.Converters;
 import br.com.caelum.vraptor.http.InvalidParameterException;
 import br.com.caelum.vraptor.validator.Message;
-import br.com.caelum.vraptor.validator.ValidationMessage;
+import br.com.caelum.vraptor.validator.SimpleMessage;
 import br.com.caelum.vraptor.validator.annotation.ValidationException;
 
 import com.google.common.collect.ImmutableList;
@@ -96,7 +96,7 @@ public class VRaptorInstantiator implements InstantiatorWithErrors, Instantiator
 	}
 	private void handleException(Target<?> target, Throwable e) {
 		if (e.getClass().isAnnotationPresent(ValidationException.class)) {
-			errors.add(new ValidationMessage(target.getName(), e.getLocalizedMessage()));
+			errors.add(new SimpleMessage(target.getName(), e.getLocalizedMessage()));
 		} else if (e.getCause() == null) {
 			throw new InvalidParameterException("Exception when trying to instantiate " + target, e);
 		} else {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/SimpleMessage.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/SimpleMessage.java
@@ -27,14 +27,14 @@ import java.util.ResourceBundle;
  *
  * @author Guilherme Silveira
  */
-public class ValidationMessage implements Message {
+public class SimpleMessage implements Message {
 
 	private static final long serialVersionUID = 1L;
 
 	private final String message, category;
 	private final Object[] messageParameters;
 
-	public ValidationMessage(String category, String message, Object... messageParameters) {
+	public SimpleMessage(String category, String message, Object... messageParameters) {
 		this.category = category;
 		this.message = message;
 		this.messageParameters = messageParameters;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MethodValidatorInterceptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MethodValidatorInterceptor.java
@@ -41,7 +41,7 @@ import br.com.caelum.vraptor.http.ParameterNameProvider;
 import br.com.caelum.vraptor.interceptor.ExecuteMethodInterceptor;
 import br.com.caelum.vraptor.interceptor.Interceptor;
 import br.com.caelum.vraptor.interceptor.ParametersInstantiatorInterceptor;
-import br.com.caelum.vraptor.validator.ValidationMessage;
+import br.com.caelum.vraptor.validator.SimpleMessage;
 
 import com.google.common.base.Joiner;
 
@@ -113,7 +113,7 @@ public class MethodValidatorInterceptor implements Interceptor {
 			BeanValidatorContext ctx = new BeanValidatorContext(v);
 			String msg = interpolator.interpolate(v.getMessageTemplate(), ctx, locale);
 			String category = extractCategory(names, v);
-			validator.add(new ValidationMessage(category, msg));
+			validator.add(new SimpleMessage(category, msg));
 			
 			logger.debug("added message {}={} for contraint violation", msg, category);
 		}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/ParametersInstantiatorInterceptorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/ParametersInstantiatorInterceptorTest.java
@@ -51,7 +51,7 @@ import br.com.caelum.vraptor.http.MutableRequest;
 import br.com.caelum.vraptor.http.ParameterNameProvider;
 import br.com.caelum.vraptor.http.ParametersProvider;
 import br.com.caelum.vraptor.validator.Message;
-import br.com.caelum.vraptor.validator.ValidationMessage;
+import br.com.caelum.vraptor.validator.SimpleMessage;
 import br.com.caelum.vraptor.view.FlashScope;
 
 public class ParametersInstantiatorInterceptorTest {
@@ -244,7 +244,7 @@ public class ParametersInstantiatorInterceptorTest {
 			@Override
 			public T answer(InvocationOnMock invocation) throws Throwable {
 				for (String message : messages) {
-					errors.add(new ValidationMessage("test", message));
+					errors.add(new SimpleMessage("test", message));
 				}
 				return value;
 			}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/VRaptorMatchers.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/VRaptorMatchers.java
@@ -25,7 +25,7 @@ import org.hamcrest.TypeSafeMatcher;
 
 import br.com.caelum.vraptor.controller.BeanClass;
 import br.com.caelum.vraptor.controller.ControllerMethod;
-import br.com.caelum.vraptor.validator.ValidationMessage;
+import br.com.caelum.vraptor.validator.SimpleMessage;
 
 /**
  * Useful matchers to use while mocking and hamcresting tests with internal
@@ -76,16 +76,16 @@ public class VRaptorMatchers {
 		};
 	}
 
-	public static Matcher<ValidationMessage> error(final String category, final String message) {
-		return new TypeSafeMatcher<ValidationMessage>() {
+	public static Matcher<SimpleMessage> error(final String category, final String message) {
+		return new TypeSafeMatcher<SimpleMessage>() {
 
 			@Override
-			protected void describeMismatchSafely(ValidationMessage item, Description mismatchDescription) {
+			protected void describeMismatchSafely(SimpleMessage item, Description mismatchDescription) {
 				mismatchDescription.appendText(" validation message='" +item.getMessage() + "', category = '"+item.getCategory()+"'");
 			}
 
 			@Override
-			protected boolean matchesSafely(ValidationMessage m) {
+			protected boolean matchesSafely(SimpleMessage m) {
 				return message.equals(m.getMessage()) && category.equals(m.getCategory());
 			}
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/DefaultValidatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/DefaultValidatorTest.java
@@ -52,7 +52,7 @@ import br.com.caelum.vraptor.view.PageResult;
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultValidatorTest {
 
-	private static final Message A_MESSAGE = new ValidationMessage("", "");
+	private static final Message A_MESSAGE = new SimpleMessage("", "");
 	private @Mock Result result = new MockResult();
 	private @Mock LogicResult logicResult;
 	private @Mock PageResult pageResult;
@@ -120,7 +120,7 @@ public class DefaultValidatorTest {
 	public void testThatValidatorGoToRedirectsToTheErrorPageImmediatellyAndNotBeforeThis() {
 		try {
 			// call all other validation methods and don't expect them to redirect
-			validator.addAll(Arrays.asList(new ValidationMessage("test", "test")));
+			validator.addAll(Arrays.asList(new SimpleMessage("test", "test")));
 
 			when(pageResult.of(MyComponent.class)).thenReturn(instance);
 
@@ -133,8 +133,8 @@ public class DefaultValidatorTest {
 
 	@Test
 	public void shouldParametrizeMessage() {
-		Message message0 = new ValidationMessage("category", "The simple message");
-		Message message1 = new ValidationMessage("category", "The {0} message", "simple");
+		Message message0 = new SimpleMessage("category", "The simple message");
+		Message message1 = new SimpleMessage("category", "The {0} message", "simple");
 
 		assertThat(message0.getMessage(), is("The simple message"));
 		assertThat(message1.getMessage(), is("The simple message"));
@@ -145,7 +145,7 @@ public class DefaultValidatorTest {
 		Client c = new Client();
 		c.name = "The name";
 
-		validator.check(c.name != null, new ValidationMessage("client.name", "not null"));
+		validator.check(c.name != null, new SimpleMessage("client.name", "not null"));
 		assertThat(validator.getErrors(), hasSize(0));
 	}
 
@@ -153,7 +153,7 @@ public class DefaultValidatorTest {
 	public void shouldAddMessageIfCheckingFails() {
 		Client c = new Client();
 
-		validator.check(c.name != null, new ValidationMessage("client.name", "not null"));
+		validator.check(c.name != null, new SimpleMessage("client.name", "not null"));
 		assertThat(validator.getErrors(), hasSize(1));
 		assertThat(validator.getErrors().get(0).getMessage(), containsString("not null"));
 	}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultStatusTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultStatusTest.java
@@ -40,7 +40,7 @@ import br.com.caelum.vraptor.util.test.MockSerializationResult;
 import br.com.caelum.vraptor.validator.I18nMessage;
 import br.com.caelum.vraptor.validator.Message;
 import br.com.caelum.vraptor.validator.SingletonResourceBundle;
-import br.com.caelum.vraptor.validator.ValidationMessage;
+import br.com.caelum.vraptor.validator.SimpleMessage;
 
 import com.google.common.collect.Lists;
 import com.google.gson.JsonSerializer;
@@ -155,7 +155,7 @@ public class DefaultStatusTest {
 
 	@Test
 	public void shouldSerializeErrorMessages() throws Exception {
-		Message normal = new ValidationMessage("category", "The message");
+		Message normal = new SimpleMessage("category", "The message");
 		I18nMessage i18ned = new I18nMessage("category", "message");
 		i18ned.setBundle(new SingletonResourceBundle("message", "Something else"));
 
@@ -175,7 +175,7 @@ public class DefaultStatusTest {
 
 	@Test
 	public void shouldSerializeErrorMessagesInJSON() throws Exception {
-		Message normal = new ValidationMessage("category", "The message");
+		Message normal = new SimpleMessage("category", "The message");
 		I18nMessage i18ned = new I18nMessage("category", "message");
 		i18ned.setBundle(new SingletonResourceBundle("message", "Something else"));
 

--- a/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/controller/HomeController.java
+++ b/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/controller/HomeController.java
@@ -32,7 +32,7 @@ import br.com.caelum.vraptor.musicjungle.dao.UserDao;
 import br.com.caelum.vraptor.musicjungle.interceptor.Public;
 import br.com.caelum.vraptor.musicjungle.interceptor.UserInfo;
 import br.com.caelum.vraptor.musicjungle.model.User;
-import br.com.caelum.vraptor.validator.ValidationMessage;
+import br.com.caelum.vraptor.validator.SimpleMessage;
 
 /**
  * This class will be responsible to login/logout users.
@@ -94,7 +94,7 @@ public class HomeController {
 		// if no user is found, adds an error message to the validator
 		// "invalid_login_or_password" is the message key from messages.properties,
 		// and that key is used with the fmt taglib in index.jsp, for example: <fmt:message key="error.key">
-		validator.check(currentUser != null, new ValidationMessage("login", "invalid_login_or_password"));
+		validator.check(currentUser != null, new SimpleMessage("login", "invalid_login_or_password"));
 		
 		// you can use "this" to redirect to another logic from this controller
 		validator.onErrorUsePageOf(this).login();

--- a/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/controller/MusicOwnerController.java
+++ b/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/controller/MusicOwnerController.java
@@ -29,7 +29,7 @@ import br.com.caelum.vraptor.musicjungle.interceptor.UserInfo;
 import br.com.caelum.vraptor.musicjungle.model.Music;
 import br.com.caelum.vraptor.musicjungle.model.MusicOwner;
 import br.com.caelum.vraptor.musicjungle.model.User;
-import br.com.caelum.vraptor.validator.ValidationMessage;
+import br.com.caelum.vraptor.validator.SimpleMessage;
 
 /**
  * The resource <code>MusicOwnerController</code> handles all 
@@ -88,10 +88,10 @@ public class MusicOwnerController {
 	    final User sessionUser = refreshUser();
 	    
 	    validator.check(user.getLogin().equals(sessionUser.getLogin()), 
-	            new ValidationMessage("user", "you_cant_add_to_others_list"));
+	            new SimpleMessage("user", "you_cant_add_to_others_list"));
 
 	    validator.check(!sessionUser.getMusics().contains(music), 
-	            new ValidationMessage("music", "you_already_have_this_music"));
+	            new SimpleMessage("music", "you_already_have_this_music"));
 
 		validator.onErrorUsePageOf(UsersController.class).home();
 

--- a/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/interceptor/AuthorizationInterceptor.java
+++ b/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/interceptor/AuthorizationInterceptor.java
@@ -29,7 +29,7 @@ import br.com.caelum.vraptor.interceptor.SimpleInterceptorStack;
 import br.com.caelum.vraptor.musicjungle.controller.HomeController;
 import br.com.caelum.vraptor.musicjungle.dao.UserDao;
 import br.com.caelum.vraptor.musicjungle.model.User;
-import br.com.caelum.vraptor.validator.ValidationMessage;
+import br.com.caelum.vraptor.validator.SimpleMessage;
 
 /**
  * Interceptor to check if the user is in the session.
@@ -70,7 +70,7 @@ public class AuthorizationInterceptor {
 		 */
 		if (current == null) {
 			// remember added parameters will survive one more request, when there is a redirect
-			result.include("errors", asList(new ValidationMessage("user", "user is not logged in")));
+			result.include("errors", asList(new SimpleMessage("user", "user is not logged in")));
 			result.redirectTo(HomeController.class).login();
 			return;
 		}


### PR DESCRIPTION
Closes #175.

This change can cause confusion with users that already uses vraptor3. But I don't know how to avoid this without creating factory methods, that sounds like too ugly for this case.

May be we can only document this in migration guide.
