### PR TITLE
excluding scan for util packages

### DIFF
--- a/vraptor-core/src/main/resources/META-INF/beans.xml
+++ b/vraptor-core/src/main/resources/META-INF/beans.xml
@@ -41,6 +41,8 @@
 		<exclude name="br.com.caelum.vraptor.deserialization.gson.*">
 			<if-class-not-available name="com.google.gson.Gson"/>
 		</exclude>
+
+		<exclude name="br.com.caelum.vraptor.util.**" />
 	</scan>
 	
 </beans>


### PR DESCRIPTION
looks all classes in follow packages are not managed, 
so... excluding cdi scan for _util_ package and subpackages. 

```
br.com.caelum.vraptor.util
br.com.caelum.vraptor.util.collections
br.com.caelum.vraptor.util.tests
```
