### PR TITLE
Wildfly needs original response

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/MutableRequest.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/MutableRequest.java
@@ -26,5 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 public interface MutableRequest extends HttpServletRequest {
 
 	void setParameter(String key, String... value);
+	
+	HttpServletRequest getOriginalRequest();
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/MutableResponse.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/MutableResponse.java
@@ -32,4 +32,6 @@ public interface MutableResponse extends HttpServletResponse {
 	interface RedirectListener {
 		void beforeRedirect();
 	}
+	
+	HttpServletResponse getOriginalResponse();
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/VRaptorRequest.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/VRaptorRequest.java
@@ -86,4 +86,9 @@ public class VRaptorRequest extends HttpServletRequestWrapper implements Mutable
 	public String toString() {
 		return String.format("[VRaptorRequest %s]", this.getRequest());
 	}
+	
+	@Override
+	public HttpServletRequest getOriginalRequest() {
+		return (HttpServletRequest) getRequest();
+	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/VRaptorResponse.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/VRaptorResponse.java
@@ -52,4 +52,9 @@ public class VRaptorResponse extends HttpServletResponseWrapper implements Mutab
 	public void addRedirectListener(RedirectListener listener) {
 		listeners.add(listener);
 	}
+	
+	@Override
+	public HttpServletResponse getOriginalResponse() {
+		return (HttpServletResponse) getResponse();
+	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultLogicResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultLogicResult.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Type;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +36,7 @@ import br.com.caelum.vraptor.controller.DefaultControllerMethod;
 import br.com.caelum.vraptor.controller.HttpMethod;
 import br.com.caelum.vraptor.core.MethodInfo;
 import br.com.caelum.vraptor.http.MutableRequest;
+import br.com.caelum.vraptor.http.MutableResponse;
 import br.com.caelum.vraptor.http.route.Router;
 import br.com.caelum.vraptor.interceptor.TypeNameExtractor;
 import br.com.caelum.vraptor.ioc.Container;
@@ -60,7 +60,7 @@ public class DefaultLogicResult implements LogicResult {
 	private final Proxifier proxifier;
 	private final Router router;
 	private final MutableRequest request;
-	private final HttpServletResponse response;
+	private final MutableResponse response;
 	private final Container container;
 	private final PathResolver resolver;
 	private final TypeNameExtractor extractor;
@@ -75,7 +75,7 @@ public class DefaultLogicResult implements LogicResult {
 	}
 
 	@Inject
-	public DefaultLogicResult(Proxifier proxifier, Router router, MutableRequest request, HttpServletResponse response,
+	public DefaultLogicResult(Proxifier proxifier, Router router, MutableRequest request, MutableResponse response,
 			Container container, PathResolver resolver, TypeNameExtractor extractor, FlashScope flash, MethodInfo methodInfo) {
 		this.proxifier = proxifier;
 		this.response = response;
@@ -112,7 +112,7 @@ public class DefaultLogicResult implements LogicResult {
 					if (!response.isCommitted()) {
 						String path = resolver.pathFor(DefaultControllerMethod.instanceFor(type, method));
 						logger.debug("Forwarding to {}", path);
-						request.getRequestDispatcher(path).forward(request, response);
+						request.getRequestDispatcher(path).forward(request.getOriginalRequest(), response.getOriginalResponse());
 					}
 					return null;
 				} catch (InvocationTargetException e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPageResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPageResult.java
@@ -74,7 +74,7 @@ public class DefaultPageResult implements PageResult {
 		String to = resolver.pathFor(requestInfo.getControllerMethod());
 		logger.debug("forwarding to {}", to);
 		try {
-			request.getRequestDispatcher(to).forward(request, response);
+			request.getRequestDispatcher(to).forward(request.getOriginalRequest(), response.getOriginalResponse());
 		} catch (ServletException e) {
 			throw new ApplicationLogicException(to + " raised an exception", e);
 		} catch (IOException e) {
@@ -87,7 +87,7 @@ public class DefaultPageResult implements PageResult {
 		try {
 			String to = resolver.pathFor(requestInfo.getControllerMethod());
 			logger.debug("including {}", to);
-			request.getRequestDispatcher(to).include(request, response);
+			request.getRequestDispatcher(to).include(request.getOriginalRequest(), response.getOriginalResponse());
 		} catch (ServletException e) {
 			throw new ResultException(e);
 		} catch (IOException e) {
@@ -115,7 +115,7 @@ public class DefaultPageResult implements PageResult {
 		logger.debug("forwarding to {}", url);
 
 		try {
-			request.getRequestDispatcher(url).forward(request, response);
+			request.getRequestDispatcher(url).forward(request.getOriginalRequest(), response.getOriginalResponse());
 		} catch (ServletException | IOException e) {
 			throw new ResultException(e);
 		}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/test/HttpServletRequestMock.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/test/HttpServletRequestMock.java
@@ -36,6 +36,7 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -429,5 +430,10 @@ public class HttpServletRequestMock implements MutableRequest {
 	@Override
 	public ServletContext getServletContext() {
 		return session.getServletContext();
+	}
+	
+	@Override
+	public HttpServletRequest getOriginalRequest() {
+		return wrapper;
 	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultLogicResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultLogicResultTest.java
@@ -118,6 +118,9 @@ public class DefaultLogicResultTest {
 
 	@Test
 	public void shouldIncludeReturnValueOnForward() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		givenDispatcherWillBeReturnedWhenRequested();
 		when(extractor.nameFor(String.class)).thenReturn("string");
 
@@ -129,6 +132,9 @@ public class DefaultLogicResultTest {
 
 	@Test
 	public void shouldExecuteTheLogicAndRedirectToItsViewOnForward() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		final MyComponent component = givenDispatcherWillBeReturnedWhenRequested();
 
 		assertThat(component.calls, is(0));
@@ -148,6 +154,9 @@ public class DefaultLogicResultTest {
 
 	@Test
 	public void shouldForwardToMethodsDefaultViewWhenResponseIsNotCommited() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		givenDispatcherWillBeReturnedWhenRequested();
 		when(response.isCommitted()).thenReturn(false);
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultPageResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultPageResultTest.java
@@ -103,6 +103,9 @@ public class DefaultPageResultTest {
 
 	@Test
 	public void shouldForwardToGivenURI() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		when(request.getRequestDispatcher("/any/url")).thenReturn(dispatcher);
 
 		view.forwardTo("/any/url");
@@ -112,6 +115,9 @@ public class DefaultPageResultTest {
 
 	@Test(expected=ResultException.class)
 	public void shouldThrowResultExceptionIfServletExceptionOccursWhileForwarding() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		when(request.getRequestDispatcher(anyString())).thenReturn(dispatcher);
 		doThrow(new ServletException()).when(dispatcher).forward(request, response);
 
@@ -120,6 +126,9 @@ public class DefaultPageResultTest {
 
 	@Test(expected=ResultException.class)
 	public void shouldThrowResultExceptionIfIOExceptionOccursWhileForwarding() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		when(request.getRequestDispatcher(anyString())).thenReturn(dispatcher);
 		doThrow(new IOException()).when(dispatcher).forward(request, response);
 
@@ -128,6 +137,9 @@ public class DefaultPageResultTest {
 
 	@Test
 	public void shouldAllowCustomPathResolverWhileForwardingView() throws ServletException, IOException {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		when(request.getRequestDispatcher("fixed")).thenReturn(dispatcher);
 
 		view.defaultView();
@@ -137,6 +149,9 @@ public class DefaultPageResultTest {
 
 	@Test(expected=ApplicationLogicException.class)
 	public void shouldThrowResultExceptionIfServletExceptionOccursWhileForwardingView() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		when(request.getRequestDispatcher(anyString())).thenReturn(dispatcher);
 		doThrow(new ServletException()).when(dispatcher).forward(request, response);
 
@@ -145,6 +160,9 @@ public class DefaultPageResultTest {
 
 	@Test(expected=ResultException.class)
 	public void shouldThrowResultExceptionIfIOExceptionOccursWhileForwardingView() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		when(request.getRequestDispatcher(anyString())).thenReturn(dispatcher);
 		doThrow(new IOException()).when(dispatcher).forward(request, response);
 
@@ -153,6 +171,9 @@ public class DefaultPageResultTest {
 
 	@Test
 	public void shouldAllowCustomPathResolverWhileIncluding() throws ServletException, IOException {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		when(request.getRequestDispatcher("fixed")).thenReturn(dispatcher);
 
 		view.include();
@@ -162,6 +183,9 @@ public class DefaultPageResultTest {
 
 	@Test(expected=ResultException.class)
 	public void shouldThrowResultExceptionIfServletExceptionOccursWhileIncluding() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		when(request.getRequestDispatcher(anyString())).thenReturn(dispatcher);
 		doThrow(new ServletException()).when(dispatcher).include(request, response);
 
@@ -170,6 +194,9 @@ public class DefaultPageResultTest {
 
 	@Test(expected=ResultException.class)
 	public void shouldThrowResultExceptionIfIOExceptionOccursWhileIncluding() throws Exception {
+		when(request.getOriginalRequest()).thenReturn(request);
+		when(response.getOriginalResponse()).thenReturn(response);
+		
 		when(request.getRequestDispatcher(anyString())).thenReturn(dispatcher);
 		doThrow(new IOException()).when(dispatcher).include(request, response);
 


### PR DESCRIPTION
As discussed on dev mailing list, we need to use original request when forward pages. So wildfly don't recognize request properly.

Testing in Wildfly, Tomcat, Jetty and Glassfish 4, all works fine, without double request.

Related to #164.
