### PR TITLE
Avoid find operation when creates cache

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/DefaultCacheStore.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/DefaultCacheStore.java
@@ -17,7 +17,9 @@ public class DefaultCacheStore<K,V> implements CacheStore<K,V> {
 	public V fetch(K key, Callable<V> valueProvider) {
 		if (!cache.containsKey(key)){
 			try {
-				cache.put(key, valueProvider.call());
+				V value = valueProvider.call();
+				cache.put(key, value);
+				return value;
 			} catch (Exception e) {
 				Throwables.propagateIfPossible(e);
 				throw new CacheException("Error computing the value", e);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/LRUCacheStore.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/LRUCacheStore.java
@@ -43,14 +43,16 @@ public class LRUCacheStore<K, V> extends LinkedHashMap<K, V> implements CacheSto
 
 	@Override
 	protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
-		return this.size() > capacity;
+		return size() > capacity;
 	}
 
 	@Override
 	public V fetch(K key, Callable<V> valueProvider) {
 		if (!this.containsKey(key)){
 			try {
-				this.put(key, valueProvider.call());
+				V value = valueProvider.call();
+				put(key, value);
+				return value;
 			} catch (Exception e) {
 				Throwables.propagateIfPossible(e);
 				throw new CacheException("Error computing the value", e);


### PR DESCRIPTION
When element is created, we can return then, instead of find in the hashmap. This change allow us to increase performance in the first call. I know that the change is too small, less than 1ns, but all performance are welcome.
