### PR TITLE
Removing debug message when Weld isn't found

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/proxy/JavassistProxifier.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/proxy/JavassistProxifier.java
@@ -15,6 +15,8 @@
  */
 package br.com.caelum.vraptor.proxy;
 
+import static javassist.util.proxy.ProxyFactory.isProxyClass;
+
 import java.lang.reflect.Method;
 
 import javassist.util.proxy.MethodFilter;
@@ -25,8 +27,6 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static javassist.util.proxy.ProxyFactory.isProxyClass;
 
 /**
  * Javassist implementation for {@link Proxifier}.
@@ -46,6 +46,7 @@ public class JavassistProxifier implements Proxifier {
 		try {
 			temp = Class.forName("org.jboss.weld.bean.proxy.ProxyObject");
 		} catch (ClassNotFoundException e) {
+			logger.debug("Weld is not present, so we can't determine if classes is a weld proxy");
 			temp = null;
 		}
 		weldProxyClass = temp;


### PR DESCRIPTION
Because when weld isn't found, logger will produce a lot of not useful messages for every check.
