### PR TITLE
Rollback to use Parameter as array

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ParameterNameProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ParameterNameProvider.java
@@ -17,7 +17,6 @@
 package br.com.caelum.vraptor.http;
 
 import java.lang.reflect.AccessibleObject;
-import java.util.List;
 
 /**
  * Provides all parameter names for an specific java method.
@@ -26,6 +25,6 @@ import java.util.List;
  */
 public interface ParameterNameProvider {
 
-	List<Parameter> parametersFor(AccessibleObject executable);
+	Parameter[] parametersFor(AccessibleObject executable);
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultParametersControl.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultParametersControl.java
@@ -94,8 +94,8 @@ public class DefaultParametersControl implements ParametersControl {
 	}
 
 	@Override
-	public String fillUri(List<Parameter> paramNames, Object... paramValues) {
-		if (paramNames.size() != paramValues.length) {
+	public String fillUri(Parameter[] paramNames, Object... paramValues) {
+		if (paramNames.length != paramValues.length) {
 			throw new IllegalArgumentException("paramNames must have the same length as paramValues. Names: " + paramNames + " Values: " + Arrays.toString(paramValues));
 		}
 
@@ -131,9 +131,9 @@ public class DefaultParametersControl implements ParametersControl {
 		}
 	}
 
-	private Object selectParam(String key, List<Parameter> paramNames, Object[] paramValues) {
-		for (int i = 0; i < paramNames.size(); i++) {
-			if (key.matches("^" + paramNames.get(i).getName() + "(\\..*|$)")) {
+	private Object selectParam(String key, Parameter[] paramNames, Object[] paramValues) {
+		for (int i = 0; i < paramNames.length; i++) {
+			if (key.matches("^" + paramNames[i].getName() + "(\\..*|$)")) {
 				return paramValues[i];
 			}
 		}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouteBuilder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouteBuilder.java
@@ -185,7 +185,7 @@ public class DefaultRouteBuilder implements RouteBuilder {
 	public void is(Class<?> type, Method method) {
 		addParametersInfo(method);
 		ControllerMethod controllerMethod = DefaultControllerMethod.instanceFor(type, method);
-		List<Parameter> parameterNames = nameProvider.parametersFor(method);
+		Parameter[] parameterNames = nameProvider.parametersFor(method);
 		this.strategy = new FixedMethodStrategy(originalUri, controllerMethod, this.supportedMethods, builder.build(), priority, parameterNames);
 
 		logger.info(String.format("%-50s%s -> %10s", originalUri,

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultTypeFinder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultTypeFinder.java
@@ -19,7 +19,6 @@ package br.com.caelum.vraptor.http.route;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -53,7 +52,7 @@ public class DefaultTypeFinder implements TypeFinder {
 	@Override
 	public Map<String, Class<?>> getParameterTypes(Method method, String[] parameterPaths) {
 		Map<String,Class<?>> result = new HashMap<>();
-		List<Parameter> parametersFor = provider.parametersFor(method);
+		Parameter[] parametersFor = provider.parametersFor(method);
 		for (String path : parameterPaths) {
 			for (Parameter parameter: parametersFor) {
 				if (path.startsWith(parameter.getName() + ".") || path.equals(parameter.getName())) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/FixedMethodStrategy.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/FixedMethodStrategy.java
@@ -20,7 +20,6 @@ package br.com.caelum.vraptor.http.route;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -42,10 +41,10 @@ public class FixedMethodStrategy implements Route {
 	private final ParametersControl parameters;
 	private final int priority;
 	private final String originalUri;
-	private final List<Parameter> parameterNames;
+	private final Parameter[] parameterNames;
 
 	public FixedMethodStrategy(String originalUri, ControllerMethod method, Set<HttpMethod> methods,
-			ParametersControl control, int priority, List<Parameter> parameterNames) {
+			ParametersControl control, int priority, Parameter[] parameterNames) {
 		this.originalUri = originalUri;
 		this.parameterNames = parameterNames;
 		this.methods = methods.isEmpty() ? EnumSet.allOf(HttpMethod.class) : EnumSet.copyOf(methods);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/ParametersControl.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/ParametersControl.java
@@ -17,8 +17,6 @@
 
 package br.com.caelum.vraptor.http.route;
 
-import java.util.List;
-
 import br.com.caelum.vraptor.http.MutableRequest;
 import br.com.caelum.vraptor.http.Parameter;
 
@@ -32,7 +30,7 @@ public interface ParametersControl {
 	/**
 	 * creates a uri based on those parameter values
 	 */
-	String fillUri(List<Parameter> paramNames, Object... paramValues);
+	String fillUri(Parameter[] paramNames, Object... paramValues);
 
 	/**
 	 * Inserts parameters extracted from the uri into the request parameters.

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/ReplicatorOutjector.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/ReplicatorOutjector.java
@@ -15,8 +15,6 @@
  */
 package br.com.caelum.vraptor.validator;
 
-import java.util.List;
-
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 
@@ -53,11 +51,11 @@ public class ReplicatorOutjector implements Outjector {
 
 	@Override
 	public void outjectRequestMap() {
-		List<Parameter> params = nameProvider.parametersFor(method.getControllerMethod().getMethod());
+		Parameter[] params = nameProvider.parametersFor(method.getControllerMethod().getMethod());
 		Object[] values = method.getParameters();
 
-		for (int i = 0; i < params.size(); i++) {
-			result.include(params.get(i).getName(), values[i]);
+		for (int i = 0; i < params.length; i++) {
+			result.include(params[i].getName(), values[i]);
 		}
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MethodValidatorInterceptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MethodValidatorInterceptor.java
@@ -15,9 +15,7 @@
  */
 package br.com.caelum.vraptor.validator.beanvalidation;
 
-import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -111,8 +109,7 @@ public class MethodValidatorInterceptor implements Interceptor {
 				.validateParameters(controllerInstance, method.getMethod(), methodInfo.getParameters());
 		logger.debug("there are {} violations at method {}.", violations.size(), method);
 
-		List<Parameter> params = violations.isEmpty() ? Collections.<Parameter> emptyList()
-				: parameterNameProvider.parametersFor(method.getMethod());
+		Parameter[] params = violations.isEmpty() ? new Parameter[0] : parameterNameProvider.parametersFor(method.getMethod());
 
 		for (ConstraintViolation<Object> v : violations) {
 			BeanValidatorContext ctx = new BeanValidatorContext(v);
@@ -131,13 +128,13 @@ public class MethodValidatorInterceptor implements Interceptor {
 	 * is the name of method with full path for property. You can override this method to
 	 * change this behaviour.
 	 */
-	protected String extractCategory(List<Parameter> params, ConstraintViolation<Object> v) {
+	protected String extractCategory(Parameter[] params, ConstraintViolation<Object> v) {
 		Iterator<Node> property = v.getPropertyPath().iterator();
 		property.next();
 		ParameterNode parameterNode = property.next().as(ParameterNode.class);
 
 		int index = parameterNode.getParameterIndex();
 		return Joiner.on(".").join(v.getPropertyPath())
-				.replace("arg" + parameterNode.getParameterIndex(), params.get(index).getName());
+				.replace("arg" + parameterNode.getParameterIndex(), params[index].getName());
 	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/deserialization/gson/GsonDeserializerTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/deserialization/gson/GsonDeserializerTest.java
@@ -55,7 +55,7 @@ public class GsonDeserializerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 		request = mock(HttpServletRequest.class);
 
 		List<JsonDeserializer<?>> adapters = new ArrayList<>();

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/deserialization/xstream/XStreamXmlDeserializerTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/deserialization/xstream/XStreamXmlDeserializerTest.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 import java.lang.reflect.AccessibleObject;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
-import java.util.List;
 import java.util.TimeZone;
 
 import org.junit.Before;
@@ -40,7 +39,7 @@ public class XStreamXmlDeserializerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 
 		deserializer = new XStreamXMLDeserializer(provider, cleanInstance(new CalendarConverter()));
 		BeanClass controllerClass = new DefaultBeanClass(DogController.class);

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/ParametersProviderTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/ParametersProviderTest.java
@@ -73,7 +73,7 @@ public abstract class ParametersProviderTest {
 	@Before
 	public void setup() throws Exception {
 		MockitoAnnotations.initMocks(this);
-		nameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		nameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 		this.provider = getProvider();
 		this.errors = new ArrayList<>();
 		

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/ParanamerNameProviderTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/ParanamerNameProviderTest.java
@@ -19,6 +19,7 @@ package br.com.caelum.vraptor.http;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.lang.reflect.AccessibleObject;
 import java.util.ArrayList;
@@ -38,11 +39,11 @@ public class ParanamerNameProviderTest {
 
 	@Before
 	public void setup() {
-		CacheStore<AccessibleObject, List<Parameter>> cache = new DefaultCacheStore<>();
+		CacheStore<AccessibleObject, Parameter[]> cache = new DefaultCacheStore<>();
 		provider = new ParanamerNameProvider(cache);
 	}
 	
-	private List<String> toNames(List<Parameter> parameters) {
+	private List<String> toNames(Parameter[] parameters) {
 		List<String> out = new ArrayList<>();
 		for (Parameter p : parameters)
 			out.add(p.getName());
@@ -51,55 +52,58 @@ public class ParanamerNameProviderTest {
 
 	@Test
 	public void shouldNameObjectTypeAsItsSimpleName() throws SecurityException, NoSuchMethodException {
-		List<Parameter> namesFor = provider.parametersFor(Horse.class.getMethod("runThrough", Field.class));
+		Parameter[] namesFor = provider.parametersFor(Horse.class.getMethod("runThrough", Field.class));
 		assertThat(toNames(namesFor), contains("f"));
 	}
 
 	@Test
 	public void shouldNamePrimitiveTypeAsItsSimpleName() throws SecurityException, NoSuchMethodException {
-		List<Parameter> namesFor = provider.parametersFor(Horse.class.getMethod("rest", int.class));
+		Parameter[] namesFor = provider.parametersFor(Horse.class.getMethod("rest", int.class));
 		assertThat(toNames(namesFor), contains("hours"));
 	}
 
 	@Test
 	public void shouldNameArrayAsItsSimpleTypeName() throws SecurityException, NoSuchMethodException {
-		List<Parameter> namesFor = provider.parametersFor(Horse.class.getMethod("setLeg", int[].class));
+		Parameter[] namesFor = provider.parametersFor(Horse.class.getMethod("setLeg", int[].class));
 		assertThat(toNames(namesFor), contains("length"));
 	}
 
 	@Test
 	public void shouldNameGenericCollectionUsingOf() throws SecurityException, NoSuchMethodException {
-		List<Parameter> namesFor = provider.parametersFor(Cat.class.getDeclaredMethod("fightWith", List.class));
+		Parameter[] namesFor = provider.parametersFor(Cat.class.getDeclaredMethod("fightWith", List.class));
 		assertThat(toNames(namesFor), contains("cats"));
 	}
 	
-	@Test(expected=UnsupportedOperationException.class)
+	@Test
 	public void shouldIgnoreChangesToTheReturnedArrayInSubsequentCalls() throws Exception {
-		List<Parameter> namesFor = provider.parametersFor(Horse.class.getMethod("setLeg", int[].class));
-		namesFor.set(0, null);
+		Parameter[] firstCall = provider.parametersFor(Horse.class.getMethod("setLeg", int[].class));
+		firstCall[0] = null;
+
+		Parameter[] secondCall = provider.parametersFor(Horse.class.getMethod("setLeg", int[].class));
+		assertThat(secondCall[0], notNullValue());
 	}
 	
 	@Test
 	public void shouldNameFieldsAnnotatedWithNamed() throws SecurityException, NoSuchMethodException  {
-		List<Parameter> namesFor = provider.parametersFor(Horse.class.getMethod("runThroughWithAnnotation", Field.class));
+		Parameter[] namesFor = provider.parametersFor(Horse.class.getMethod("runThroughWithAnnotation", Field.class));
 		assertThat(toNames(namesFor), contains("one"));
 	}
 	
 	@Test
 	public void shouldNotNameFieldsByTheFieldNameWhenUsingAnnotation() throws SecurityException, NoSuchMethodException  {
-		List<Parameter> namesFor = provider.parametersFor(Horse.class.getMethod("runThroughWithAnnotation", Field.class));
+		Parameter[] namesFor = provider.parametersFor(Horse.class.getMethod("runThroughWithAnnotation", Field.class));
 		assertThat(toNames(namesFor), not(contains("field")));
 	}
 
 	@Test
 	public void shouldNameMethodsFieldsWhenAnnotatedOrNot() throws SecurityException, NoSuchMethodException  {
-		List<Parameter> namesFor = provider.parametersFor(Horse.class.getMethod("runThroughWithAnnotation2", Field.class, Field.class));
+		Parameter[] namesFor = provider.parametersFor(Horse.class.getMethod("runThroughWithAnnotation2", Field.class, Field.class));
 		assertThat(toNames(namesFor), contains("one", "two"));
 	}
 	
 	@Test
 	public void shouldNameMethodsFieldsWhenAnnotatedOrNot2() throws SecurityException, NoSuchMethodException  {
-		List<Parameter> namesFor = provider.parametersFor(Horse.class.getMethod("runThroughWithAnnotation3", Field.class, Field.class));
+		Parameter[] namesFor = provider.parametersFor(Horse.class.getMethod("runThroughWithAnnotation3", Field.class, Field.class));
 		assertThat(toNames(namesFor), contains("one", "size"));
 	}
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/DefaultParametersControlTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/DefaultParametersControlTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +57,7 @@ public class DefaultParametersControlTest {
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
 		evaluator = new JavaEvaluator();
-		nameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		nameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 	}
 
 	@Test

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/DefaultRouterTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/DefaultRouterTest.java
@@ -80,7 +80,7 @@ public class DefaultRouterTest {
 		this.method = mock(ControllerMethod.class);
 		this.converters = mock(Converters.class);
 		this.encodingHandler = mock(EncodingHandler.class);
-		this.nameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		this.nameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 		this.cache = new DefaultCacheStore<>();
 
 		router = new DefaultRouter(proxifier, new NoTypeFinder(), converters, nameProvider, new JavaEvaluator(), encodingHandler,cache);

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/DefaultTypeFinderTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/DefaultTypeFinderTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.Map;
 
 import net.vidageek.mirror.dsl.Mirror;
@@ -39,7 +38,7 @@ public class DefaultTypeFinderTest {
 	
 	@Before
 	public void setup() {
-		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 	}
 
 	public static class AController {

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/FixedMethodStrategyTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/FixedMethodStrategyTest.java
@@ -26,9 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
 
 import org.junit.Before;
@@ -64,8 +62,7 @@ public class FixedMethodStrategyTest {
 
 	@Test
 	public void canTranslate() {
-		FixedMethodStrategy strategy = new FixedMethodStrategy("abc", list,
-				methods(HttpMethod.POST), control, 0, Collections.<Parameter> emptyList());
+		FixedMethodStrategy strategy = new FixedMethodStrategy("abc", list, methods(HttpMethod.POST), control, 0, new Parameter[0]);
 		when(control.matches("/clients/add")).thenReturn(true);
 		ControllerMethod match = strategy.controllerMethod(request, "/clients/add");
 		assertThat(match, is(VRaptorMatchers.controllerMethod(method("list"))));
@@ -74,11 +71,10 @@ public class FixedMethodStrategyTest {
 
 	@Test
 	public void areEquals() throws Exception {
-		List<Parameter> emptyParams = Collections.emptyList();
-		FixedMethodStrategy first = new FixedMethodStrategy("/uri", list, get, control, 0, emptyParams);
-		FixedMethodStrategy second = new FixedMethodStrategy("/uri", list, get, control, 2, emptyParams);
-		FixedMethodStrategy third = new FixedMethodStrategy("/different", list, get, control, 2, emptyParams);
-		FixedMethodStrategy forth = new FixedMethodStrategy("/uri", list, post, control, 2, emptyParams);
+		FixedMethodStrategy first = new FixedMethodStrategy("/uri", list, get, control, 0, new Parameter[0]);
+		FixedMethodStrategy second = new FixedMethodStrategy("/uri", list, get, control, 2, new Parameter[0]);
+		FixedMethodStrategy third = new FixedMethodStrategy("/different", list, get, control, 2, new Parameter[0]);
+		FixedMethodStrategy forth = new FixedMethodStrategy("/uri", list, post, control, 2, new Parameter[0]);
 
 		assertThat(first, equalTo(second));
 		assertThat(first, not(equalTo(third)));

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/PathAnnotationRoutesParserTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/PathAnnotationRoutesParserTest.java
@@ -76,7 +76,7 @@ public class PathAnnotationRoutesParserTest {
 
 		this.proxifier = new JavassistProxifier();
 		this.typeFinder = new NoTypeFinder();
-		nameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		nameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 
 		when(router.builderFor(anyString())).thenAnswer(new Answer<DefaultRouteBuilder>() {
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/RouteBuilderTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/http/route/RouteBuilderTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -65,7 +64,7 @@ public class RouteBuilderTest {
 	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 
-		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 		
 		method = new DefaultControllerMethod(new DefaultBeanClass(MyResource.class), MyResource.class.getMethod(
 				"method", String.class, Integer.class, BigDecimal.class));

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/ParametersInstantiatorInterceptorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/ParametersInstantiatorInterceptorTest.java
@@ -78,7 +78,7 @@ public class ParametersInstantiatorInterceptorTest {
 	@Before
 	@SuppressWarnings("unchecked")
 	public void setup() throws Exception {
-		parameterNameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		parameterNameProvider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 
 		MockitoAnnotations.initMocks(this);
 		when(request.getParameterNames()).thenReturn(Collections.<String> emptyEnumeration());

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MethodValidatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MethodValidatorTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.lang.reflect.AccessibleObject;
-import java.util.List;
 import java.util.Locale;
 
 import javax.validation.MessageInterpolator;
@@ -54,7 +53,7 @@ public class MethodValidatorTest {
 
 		Locale.setDefault(Locale.ENGLISH);
 
-		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 		
 		validatorFactory = javax.validation.Validation.buildDefaultValidatorFactory();
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/ReplicatorOutjectorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/ReplicatorOutjectorTest.java
@@ -4,7 +4,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.AccessibleObject;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +33,7 @@ public class ReplicatorOutjectorTest {
 		when(controllerMethod.getMethod()).thenReturn(getClass().getDeclaredMethod("foo", int.class, float.class, long.class));
 		when(method.getControllerMethod()).thenReturn(controllerMethod);
 
-		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, List<Parameter>>());
+		provider = new ParanamerNameProvider(new DefaultCacheStore<AccessibleObject, Parameter[]>());
 		outjector = new ReplicatorOutjector(result, method, provider);
 	}
 


### PR DESCRIPTION
This pull request rollback #226, that uses Parameter as list. The motivation for this is because `Method.getParameters()` from Java 8 returns an array of parameters. This change allow us to stay closer of Java 8.
