### PR TITLE
removing final to enable mocking this class

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/Parameter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/Parameter.java
@@ -13,7 +13,7 @@ import java.util.Objects;
  * 
  * @author Otávio Scherer Garcia
  */
-public final class Parameter implements AnnotatedElement {
+public class Parameter implements AnnotatedElement {
 
 	private final int index;
 	private final String name;


### PR DESCRIPTION
Since this class its hard to instantiate, it should not be final so that we can mock it for testing.

I'm trying to update vraptor-plugin-hibernate4 and we need to mock Parameter class in its tests.

btw, we have two repositories for vraptor-plugin-hibernate4, the one in @garcia-jj and in @caelum, I'm developing in the caelum repo...
