### PR TITLE
moving from interceptor to observer package

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/OutjectResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/OutjectResult.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package br.com.caelum.vraptor.interceptor;
+package br.com.caelum.vraptor.observer;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import br.com.caelum.vraptor.Result;
 import br.com.caelum.vraptor.core.MethodInfo;
 import br.com.caelum.vraptor.events.MethodExecuted;
+import br.com.caelum.vraptor.interceptor.TypeNameExtractor;
 
 /**
  * Outjects the result of the method invocation to the desired result

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParameterIncluder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParameterIncluder.java
@@ -1,4 +1,4 @@
-package br.com.caelum.vraptor.interceptor;
+package br.com.caelum.vraptor.observer;
 
 import java.lang.reflect.Method;
 
@@ -8,6 +8,7 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import br.com.caelum.vraptor.events.ReadyToExecuteMethod;
+import br.com.caelum.vraptor.interceptor.IncludeParameters;
 import br.com.caelum.vraptor.validator.Outjector;
 
 /**

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/OutjectResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/OutjectResultTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package br.com.caelum.vraptor.interceptor;
+package br.com.caelum.vraptor.observer;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +33,8 @@ import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.core.InterceptorStack;
 import br.com.caelum.vraptor.core.MethodInfo;
 import br.com.caelum.vraptor.events.MethodExecuted;
+import br.com.caelum.vraptor.interceptor.TypeNameExtractor;
+import br.com.caelum.vraptor.observer.OutjectResult;
 
 public class OutjectResultTest {
 


### PR DESCRIPTION
moving internal observers from interceptor to observer package

```
 rename main/java/br/com/caelum/vraptor/{interceptor => observer}/OutjectResult.java 
 rename main/java/br/com/caelum/vraptor/{interceptor => observer}/ParameterIncluder.java
 rename test/java/br/com/caelum/vraptor/{interceptor => observer}/OutjectResultTest.java
```
