### PR TITLE
starting InterceptorStack only if controller was found. Closes #279

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
@@ -37,7 +37,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 
-import br.com.caelum.vraptor.core.InterceptorStack;
 import br.com.caelum.vraptor.core.RequestInfo;
 import br.com.caelum.vraptor.core.StaticContentHandler;
 import br.com.caelum.vraptor.events.NewRequest;
@@ -80,9 +79,6 @@ public class VRaptor implements Filter {
 	private EncodingHandler encodingHandler;
 
 	@Inject
-	private InterceptorStack stack;
-
-	@Inject
 	private Event<NewRequest> newRequestEvent;
 
 	@Override
@@ -117,7 +113,6 @@ public class VRaptor implements Filter {
 				encodingHandler.setEncoding(baseRequest, baseResponse);
 				provider.provideForRequest(request);
 				newRequestEvent.fire(new NewRequest());
-				stack.start();
 
 			} catch (ApplicationLogicException e) {
 				// it is a business logic exception, we dont need to show

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/events/ControllerMethodDiscovered.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/events/ControllerMethodDiscovered.java
@@ -2,10 +2,10 @@ package br.com.caelum.vraptor.events;
 
 import br.com.caelum.vraptor.controller.BeanClass;
 import br.com.caelum.vraptor.controller.ControllerMethod;
-import br.com.caelum.vraptor.observer.ControllerLookupObserver;
+import br.com.caelum.vraptor.observer.RequestHandlerObserver;
 
 /**
- * fired by {@link ControllerLookupObserver}
+ * fired by {@link RequestHandlerObserver}
  *
  * @author Rodrigo Turini
  */

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/TopologicalSortedInterceptorRegistryTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/TopologicalSortedInterceptorRegistryTest.java
@@ -11,7 +11,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 
 import br.com.caelum.vraptor.Intercepts;
-import br.com.caelum.vraptor.observer.ControllerLookupObserver;
+import br.com.caelum.vraptor.observer.RequestHandlerObserver;
 
 public class TopologicalSortedInterceptorRegistryTest {
 
@@ -97,11 +97,11 @@ public class TopologicalSortedInterceptorRegistryTest {
 	public void usesDefaultInterceptorsIfNoRelationIsSet() throws Exception {
 		TopologicalSortedInterceptorRegistry set = new TopologicalSortedInterceptorRegistry();
 		set.register(A.class);
-		assertThat(set.all(), hasRelativeOrder(ControllerLookupObserver.class, A.class, ExecuteMethodInterceptor.class));
+		assertThat(set.all(), hasRelativeOrder(RequestHandlerObserver.class, A.class, ExecuteMethodInterceptor.class));
 
 		set = new TopologicalSortedInterceptorRegistry();
 		set.register(F.class);
-		assertThat(set.all(), hasRelativeOrder(ControllerLookupObserver.class, F.class, ExecuteMethodInterceptor.class));
+		assertThat(set.all(), hasRelativeOrder(RequestHandlerObserver.class, F.class, ExecuteMethodInterceptor.class));
 	}
 
 	@Test


### PR DESCRIPTION
The `ControllerLookupObservers` was renamed to `RequestHandlerObserver`, and 
only if a `ControllerMethod` for a specific request was found, starts `InterceptorStack`.
