### PR TITLE
Only ask CDI if at least one bean is found

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIBasedContainer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIBasedContainer.java
@@ -40,6 +40,10 @@ public class CDIBasedContainer implements Container {
 
 	private <T> T selectFromContainer(final Class<T> type) {
 		Set<Bean<?>> beans = beanManager.getBeans(type);
+		if (beans.isEmpty()) { // if no beans found
+			return null;
+		}
+		
 		Bean<? extends Object> bean = beanManager.resolve(beans);
 		CreationalContext<?> ctx = beanManager.createCreationalContext(bean);
 		return (T) beanManager.getReference(bean, type, ctx);


### PR DESCRIPTION
Only ask CDI for bean instance if at least one bean is found. 

Without this, if we uses classes that are not managed by CDI, execution fails.
