### PR TITLE
InstanceFor always return a non null bean. #283

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIBasedContainer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIBasedContainer.java
@@ -42,7 +42,6 @@ public class CDIBasedContainer implements Container {
 
 	private <T> Bean<?> getBeanFrom(Class<T> type) {
 		Set<Bean<?>> beans = beanManager.getBeans(type);
-		if (beans.isEmpty()) return null;
 		return beanManager.resolve(beans);
 	}
 }


### PR DESCRIPTION
As discussed with @asouza in #283 

`canProvide` check if bean instance can provided by CDI container. And `instanceFor` now returns a bean instance or an exception if bean is not found, instead returning a bad `null` reference.
