### PR TITLE
Removing unnecessary statement

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/SessionFlashScope.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/SessionFlashScope.java
@@ -47,10 +47,10 @@ public class SessionFlashScope implements FlashScope {
 
 	@Override
 	public Object[] consumeParameters(ControllerMethod method) {
-		Object[] args = (Object[]) session.getAttribute(nameFor(method));
-		if (args != null) {
-			session.removeAttribute(nameFor(method));
-		}
+		String param = nameFor(method);
+		Object[] args = (Object[]) session.getAttribute(param);
+		session.removeAttribute(param);
+
 		return args;
 	}
 


### PR DESCRIPTION
Because `HttpSession.removeAttribute` always check if attribute is not null before remove.
