### PR TITLE
CDI manage only annotated beans

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/DefaultCacheStore.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/DefaultCacheStore.java
@@ -4,11 +4,13 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Default;
 
 import com.google.common.base.Throwables;
 
 @Default
+@Dependent
 public class DefaultCacheStore<K,V> implements CacheStore<K,V> {
 
 	private final ConcurrentMap<K,V> cache = new ConcurrentHashMap<>();

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/ToInstantiateInterceptorHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/ToInstantiateInterceptorHandler.java
@@ -17,6 +17,8 @@
 
 package br.com.caelum.vraptor.core;
 
+import javax.enterprise.context.Dependent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +32,7 @@ import br.com.caelum.vraptor.ioc.Container;
  *
  * @author Guilherme Silveira
  */
+@Dependent
 public class ToInstantiateInterceptorHandler implements InterceptorHandler {
 
 	private static final Logger logger = LoggerFactory.getLogger(ToInstantiateInterceptorHandler.class);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ExecuteMethod.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ExecuteMethod.java
@@ -22,6 +22,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.lang.reflect.Method;
 
+import javax.enterprise.context.RequestScoped;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -48,6 +49,7 @@ import br.com.caelum.vraptor.validator.Validator;
  * @author Rodrigo Turini
  * @author Victor Harada
  */
+@RequestScoped
 public class ExecuteMethod {
 
 	private final static Logger log = getLogger(ExecuteMethod.class);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ForwardToDefaultView.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ForwardToDefaultView.java
@@ -19,6 +19,7 @@ package br.com.caelum.vraptor.observer;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import javax.enterprise.context.RequestScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -36,6 +37,7 @@ import br.com.caelum.vraptor.view.Results;
  * @author Rodrigo Turini
  * @author Victor Harada
  */
+@RequestScoped
 public class ForwardToDefaultView {
 	
 	private final Result result;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParametersInstantiator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParametersInstantiator.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 
+import javax.enterprise.context.RequestScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -46,6 +47,7 @@ import br.com.caelum.vraptor.view.FlashScope;
  * @author Rodrigo Turini
  * @author Victor Harada
  */
+@RequestScoped
 public class ParametersInstantiator {
 	
 	private static final Logger logger = getLogger(ParametersInstantiator.class);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPageResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPageResult.java
@@ -20,6 +20,7 @@ package br.com.caelum.vraptor.view;
 import java.io.IOException;
 import java.lang.reflect.Method;
 
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.servlet.ServletException;
 
@@ -42,6 +43,7 @@ import br.com.caelum.vraptor.proxy.SuperMethod;
  * @author Guilherme Silveira
  * @author Lucas Cavalcanti
  */
+@RequestScoped
 public class DefaultPageResult implements PageResult {
 
 	private static final Logger logger = LoggerFactory.getLogger(DefaultPageResult.class);

--- a/vraptor-core/src/main/resources/META-INF/beans.xml
+++ b/vraptor-core/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
-         http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-         version="1.1" bean-discovery-mode="all">
-         
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+	version="1.1" bean-discovery-mode="annotated">
+
 	<scan>
 		<exclude name="br.com.caelum.vraptor.converter.jodatime.*">
 			<if-class-not-available name="org.joda.time.LocalDate"/>
@@ -13,15 +12,15 @@
 		<exclude name="br.com.caelum.vraptor.validator.beanvalidation.*">
 			<if-class-not-available name="javax.validation.executable.ExecutableValidator"/>
 		</exclude>
-		
+
 		<exclude name="br.com.caelum.vraptor.observer.upload.CommonsUploadMultipartInterceptor">
 			<if-class-not-available name="org.apache.commons.fileupload.FileItem"/>
 		</exclude>
-		
+
 		<exclude name="br.com.caelum.vraptor.observer.upload.NullMultipartObserver">
 			<if-class-available name="org.apache.commons.fileupload.FileItem"/>
 		</exclude>
-		
+
 		<exclude name="br.com.caelum.vraptor.serialization.xstream.*">
 			<if-class-not-available name="com.thoughtworks.xstream.XStream"/>
 		</exclude>
@@ -39,9 +38,7 @@
 		</exclude>
 
 		<exclude name="br.com.caelum.vraptor.util.**" />
-		
+
 		<exclude name="br.com.caelum.vraptor.events.*" />
-		
 	</scan>
-	
 </beans>


### PR DESCRIPTION
At this time, CDI manages all classes inside vraptor jar. And this may expensive.

By the CDI 1.1 spec: **It is strongly recommended you use "annotated"**. If the bean discovery mode is "all", then all types in this archive will be considered. If the bean discovery mode is "annotated", then **only those types with bean defining annotations will be considered**. If the bean discovery mode is "none", then no types will be considered.

I did some tests in my app and I see that with annotated memory usage was lower. If need, I can share results.

So I think that we don't need that all beans are managed. There are no technical issues to use discovery as annotated, and annotate beans that we want to be managed.
