### PR TITLE
Update Vraptor4 to 4.0.0-beta-4

### DIFF
--- a/vraptor-musicjungle/pom.xml
+++ b/vraptor-musicjungle/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>br.com.caelum</groupId>
 			<artifactId>vraptor</artifactId>
-			<version>4.0.0-RC1-SNAPSHOT</version>
+			<version>4.0.0-beta-4</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Msg de erro: [ERROR] Failed to execute goal on project vraptor-musicjungle: Could not resolve dependencies for project br.com.caelum:vraptor-musicjungle:war:4.0.0-beta-4: Could not find artifact br.com.caelum:vraptor:jar:4.0.0-RC1-SNAPSHOT -> [Help 1]
