### PR TITLE
Using Guava to group messages

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/ErrorList.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/ErrorList.java
@@ -16,7 +16,7 @@ import com.google.common.collect.ForwardingList;
  */
 public class ErrorList extends ForwardingList<Message> {
 
-	private static Function<Message, String> groupByCategory = new Function<Message, String>() {
+	private static Function<Message, String> byCategory = new Function<Message, String>() {
 		@Override
 		public String apply(Message input) {
 			return input.getCategory();
@@ -36,7 +36,7 @@ public class ErrorList extends ForwardingList<Message> {
 	 */
 	public Map<String, Collection<Message>> getGrouped() {
 		if (grouped == null) {
-			grouped = index(delegate, groupByCategory).asMap();
+			grouped = index(delegate, byCategory).asMap();
 		}
 		return grouped;
 	}


### PR DESCRIPTION
As @lucascs suggested in another issue. But I had to change `asMap` return type. But since this method is too newer I think that is not problem. We can apply in vraptor 3 later. And returning message we can allow users to use methods inside Message. Returning only String with message content is more strict.
