### PR TITLE
Updating xstream due security issues and other improvements

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.4</version>
+			<version>1.4.7</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
As described in release notes:

> This maintenance release addresses mainly the security vulnerability CVE-2013-7285, an arbitrary execution of commands when unmarshalling.

And with 1.4.6 works fine under GAE/J environment. May be useful in the future when vraptor4 can be able to run under GAE. Issues XSTR-566 and XSTR-200.
