### PR TITLE
Extract linkto class mappping to a method

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/ControllerHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/ControllerHandler.java
@@ -66,7 +66,10 @@ public class ControllerHandler{
 		for (Route route : routes) {
 			router.add(route);
 		}
-		context.setAttribute(annotatedType.getType().getSimpleName(), annotatedType);
+		registerLinkToClass(annotatedType);
 	}
 
+	private void registerLinkToClass(BeanClass annotatedType) {
+		context.setAttribute(annotatedType.getType().getSimpleName(), annotatedType);
+	}
 }


### PR DESCRIPTION
With this change we can easily understand that setAttribute is used for linkto feature.
