### PR TITLE
Enable paranamer if available in classpath

### DIFF
--- a/vraptor-core/src/main/resources/META-INF/beans.xml
+++ b/vraptor-core/src/main/resources/META-INF/beans.xml
@@ -29,6 +29,10 @@
 			<if-class-not-available name="com.google.gson.Gson"/>
 		</exclude>
 
+		<exclude name="br.com.caelum.vraptor.http.ParanamerNameProvider">
+			<if-class-not-available name="com.thoughtworks.paranamer.Paranamer"/>
+		</exclude>
+
 		<exclude name="br.com.caelum.vraptor.util.**" />
 
 		<exclude name="br.com.caelum.vraptor.events.*" />


### PR DESCRIPTION
Will help us to use JDK8 without paranamer.
