### PR TITLE
Check for tempdir once

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/DefaultMultipartConfig.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/DefaultMultipartConfig.java
@@ -53,9 +53,10 @@ public class DefaultMultipartConfig implements MultipartConfig {
 	public File getDirectory() {
 		if (tmpdir == null) {
 			tmpdir = getTemporaryDirectory();
-			if (tmpdir == null) {
-				tmpdir = createDirInsideApplication();
-			}
+		}
+
+		if (tmpdir == null) {
+			tmpdir = createDirInsideApplication();
 		}
 
 		return tmpdir.toFile();


### PR DESCRIPTION
At this time we create a temp file on each time that upload was requested. For applications that have a lot of upload requests, application may stay slow.

So with this change we create a temp file once, and store the reference in a attribute.
