### PR TITLE
Dropped Jetty plugin

### DIFF
--- a/vraptor-blank-project/pom.xml
+++ b/vraptor-blank-project/pom.xml
@@ -76,20 +76,6 @@
 			</plugin>
 			
 			<plugin>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.1.1.v20140108</version>				
-				<configuration>
-					<scanIntervalSeconds>3</scanIntervalSeconds>
-					<stopKey>foo</stopKey>
-					<stopPort>9999</stopPort>
-					<webAppConfig>
-						<contextPath>/</contextPath>
-					</webAppConfig>
-				</configuration>
-			</plugin>
-
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>2.8</version>


### PR DESCRIPTION
Because blank project should contains only basic artifacts.
