### PR TITLE
Suppress the warning from tomcat

### DIFF
--- a/vraptor-musicjungle/src/main/resources/log4j.xml
+++ b/vraptor-musicjungle/src/main/resources/log4j.xml
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<!DOCTYPE log4j:configuration SYSTEM "http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/xml/doc-files/log4j.dtd">
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-        
-        <appender name="stdout" class="org.apache.log4j.ConsoleAppender">
-                <layout class="org.apache.log4j.PatternLayout">
-                        <param name="ConversionPattern" 
-                                value="%d{HH:mm:ss,SSS} %5p [%-20c{1}] %m%n"/>
-                </layout>
-        </appender>
 
-        <category name="br.com.caelum">
-	        <priority value="DEBUG" />
-	        <appender-ref ref="stdout" />
-	    </category>
+	<appender name="stdout" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%d{HH:mm:ss,SSS} %5p [%-20c{1}] %m%n" />
+		</layout>
+	</appender>
 
-        <category name="org.hibernate">
-                <priority value="INFO" />
-                <appender-ref ref="stdout" />
-        </category>
-        
-<!--         <category name="org.jboss.weld"> -->
-<!--                 <priority value="DEBUG" /> -->
-<!--                 <appender-ref ref="stdout" /> -->
-<!--         </category>         -->
+	<category name="br.com.caelum">
+		<priority value="DEBUG" />
+		<appender-ref ref="stdout" />
+	</category>
+
+	<category name="org.hibernate">
+		<priority value="INFO" />
+		<appender-ref ref="stdout" />
+	</category>
+
+	<category name="org.jboss">
+		<priority value="INFO" />
+		<appender-ref ref="stdout" />
+	</category>
 
 </log4j:configuration>


### PR DESCRIPTION
Tomcat don't recognize logger without <code>org.jboss</code> category:

```
log4j:WARN No appenders could be found for logger (org.jboss.logging).
log4j:WARN Please initialize the log4j system properly.
```

You can test using master version and running <code>mvn tomcat7:run</code>

This change was discussed before in #406
