### PR TITLE
Upgrading Hibernate Validator due performance issues

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -133,7 +133,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>5.0.0.Final</version>
+			<version>5.1.0.Final</version>
 			<optional>true</optional>
 		</dependency>
 		<!-- /bean validation -->


### PR DESCRIPTION
As described here: http://in.relation.to/Bloggers/DontWaitUpgradeHibernateValidator510FinalIsOut

> The main goal of Hibernate Validator 5.1 was to improve performance and memory footprint after releasing the initial reference implementation for Bean Validation 1.1. We achieved both and squashed several bugs along the way. If you want to know more have a look at HV-589, HV-637, HV-838 and HV-842.
