### PR TITLE
Can't rely on observers execution order

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIRequestFactories.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIRequestFactories.java
@@ -18,33 +18,33 @@ import br.com.caelum.vraptor.http.MutableResponse;
 @Priority(Interceptor.Priority.LIBRARY_BEFORE)
 public class CDIRequestFactories {
 
-	private NewRequest info;
+	private NewRequest newRequest;
 
-	public void setRequest(@Observes NewRequest info) {
-		this.info = info;
+	public void setRequest(NewRequest info) {
+		this.newRequest = info;
 	}
 	
 	@Produces
 	@RequestScoped
 	public HttpSession getSession(){
-		return info.getRequest().getSession();
+		return newRequest.getRequest().getSession();
 	}
 	
 	@Produces
 	@RequestScoped
 	public MutableResponse getResponse(){
-		return info.getResponse();
+		return newRequest.getResponse();
 	}
 	
 	@Produces
 	@RequestScoped
 	public MutableRequest getRequest(){
-		return info.getRequest();
+		return newRequest.getRequest();
 	}
 	
 	@Produces
 	@RequestScoped
 	public FilterChain getChain(){
-		return info.getChain();
+		return newRequest.getChain();
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/RequestHandlerObserver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/RequestHandlerObserver.java
@@ -35,6 +35,7 @@ import br.com.caelum.vraptor.events.NewRequest;
 import br.com.caelum.vraptor.http.UrlToControllerTranslator;
 import br.com.caelum.vraptor.http.route.ControllerNotFoundException;
 import br.com.caelum.vraptor.http.route.MethodNotAllowedException;
+import br.com.caelum.vraptor.ioc.cdi.CDIRequestFactories;
 
 /**
  * Looks up the {@link ControllerMethod} for a specific request and start {@link 
@@ -73,8 +74,9 @@ public class RequestHandlerObserver {
 		this.interceptorStack = interceptorStack;
 	}
 
-	public void handle(@Observes NewRequest event) {
+	public void handle(@Observes NewRequest event, CDIRequestFactories factories) {
 		try {
+			factories.setRequest(event);
 			ControllerMethod method = translator.translate(event.getRequest());
 			controllerFoundEvent.fire(new ControllerFound(method));
 			interceptorStack.start();

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/RequestHandlerObserverTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/RequestHandlerObserverTest.java
@@ -44,6 +44,7 @@ import br.com.caelum.vraptor.http.MutableResponse;
 import br.com.caelum.vraptor.http.UrlToControllerTranslator;
 import br.com.caelum.vraptor.http.route.ControllerNotFoundException;
 import br.com.caelum.vraptor.http.route.MethodNotAllowedException;
+import br.com.caelum.vraptor.ioc.cdi.CDIRequestFactories;
 
 public class RequestHandlerObserverTest {
 
@@ -68,7 +69,7 @@ public class RequestHandlerObserverTest {
 	@Test
 	public void shouldHandle404() throws Exception {
 		when(translator.translate(webRequest)).thenThrow(new ControllerNotFoundException());
-		observer.handle(newRequest);
+		observer.handle(newRequest, new CDIRequestFactories());
 		verify(notFoundHandler).couldntFind(chain, webRequest, webResponse);
 		verify(interceptorStack, never()).start();
 	}
@@ -77,7 +78,7 @@ public class RequestHandlerObserverTest {
 	public void shouldHandle405() throws Exception {
 		EnumSet<HttpMethod> allowedMethods = EnumSet.of(HttpMethod.GET);
 		when(translator.translate(webRequest)).thenThrow(new MethodNotAllowedException(allowedMethods, POST.toString()));
-		observer.handle(newRequest);
+		observer.handle(newRequest, new CDIRequestFactories());
 		verify(methodNotAllowedHandler).deny(webRequest, webResponse, allowedMethods);
 		verify(interceptorStack, never()).start();
 	}
@@ -86,7 +87,7 @@ public class RequestHandlerObserverTest {
 	public void shouldUseControllerMethodFoundWithNextInterceptor() throws Exception {
 		final ControllerMethod method = mock(ControllerMethod.class);
 		when(translator.translate(webRequest)).thenReturn(method);
-		observer.handle(newRequest);
+		observer.handle(newRequest, new CDIRequestFactories());
 		verify(interceptorStack).start();
 	}
 }


### PR DESCRIPTION
If RequestHandlerObserver get's a new request before CDIRequestFactories, we get NPE =/

so setting the request on the factories manually.

Any better way?
