### PR TITLE
Renaming all events, to add some naming consistency

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
@@ -39,7 +39,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 
 import br.com.caelum.vraptor.core.StaticContentHandler;
-import br.com.caelum.vraptor.events.NewRequest;
+import br.com.caelum.vraptor.events.RequestStarted;
 import br.com.caelum.vraptor.events.VRaptorInitialized;
 import br.com.caelum.vraptor.http.EncodingHandler;
 import br.com.caelum.vraptor.http.VRaptorRequest;
@@ -73,7 +73,7 @@ public class VRaptor implements Filter {
 	private Event<VRaptorInitialized> initializedEvent;
 
 	@Inject
-	private Event<NewRequest> newRequestEvent;
+	private Event<RequestStarted> requestStartedEvent;
 	
 	@Override
 	public void init(FilterConfig cfg) throws ServletException {
@@ -105,11 +105,11 @@ public class VRaptor implements Filter {
 			VRaptorRequest mutableRequest = new VRaptorRequest(baseRequest);
 			VRaptorResponse mutableResponse = new VRaptorResponse(baseResponse);
 
-			final NewRequest request = new NewRequest(chain, mutableRequest, mutableResponse);
+			final RequestStarted request = new RequestStarted(chain, mutableRequest, mutableResponse);
 
 			try {
 				encodingHandler.setEncoding(baseRequest, baseResponse);
-				newRequestEvent.fire(request);
+				requestStartedEvent.fire(request);
 			} catch (ApplicationLogicException e) {
 				// it is a business logic exception, we dont need to show
 				// all interceptors stack trace

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/events/InterceptorsExecuted.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/events/InterceptorsExecuted.java
@@ -9,12 +9,12 @@ import br.com.caelum.vraptor.core.InterceptorStack;
  * @author Rodrigo Turini
  * @author Victor Harada
  */
-public class EndOfInterceptorStack {
+public class InterceptorsExecuted {
 
 	private ControllerMethod controllerMethod;
 	private Object controllerInstance;
 
-	public EndOfInterceptorStack(ControllerMethod controllerMethod, Object controllerInstance) {
+	public InterceptorsExecuted(ControllerMethod controllerMethod, Object controllerInstance) {
 		this.controllerMethod = controllerMethod;
 		this.controllerInstance = controllerInstance;
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/events/InterceptorsReady.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/events/InterceptorsReady.java
@@ -11,11 +11,11 @@ import br.com.caelum.vraptor.observer.RequestHandlerObserver;
  * @author Rodrigo Turini
  * @author Victor Kendy Harada
  */
-public class StackStarting {
+public class InterceptorsReady {
 
 	private ControllerMethod method;
 
-	public StackStarting(ControllerMethod method) {
+	public InterceptorsReady(ControllerMethod method) {
 		this.method = method;
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/events/MethodReady.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/events/MethodReady.java
@@ -9,11 +9,11 @@ import br.com.caelum.vraptor.observer.ExecuteMethod;
  * @author Rodrigo Turini
  * @since 4.0
  */
-public class ReadyToExecuteMethod {
+public class MethodReady {
 
 	private final ControllerMethod controllermethod;
 
-	public ReadyToExecuteMethod(ControllerMethod method) {
+	public MethodReady(ControllerMethod method) {
 		this.controllermethod = method;
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/events/RequestStarted.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/events/RequestStarted.java
@@ -28,13 +28,13 @@ import br.com.caelum.vraptor.http.MutableResponse;
  * @author Fabio Kung
  * @author Guilherme Silveira
  */
-public class NewRequest {
+public class RequestStarted {
 
 	private final MutableRequest request;
 	private final MutableResponse response;
 	private final FilterChain chain;
 
-	public NewRequest(FilterChain chain, MutableRequest request, MutableResponse response) {
+	public RequestStarted(FilterChain chain, MutableRequest request, MutableResponse response) {
 		this.chain = chain;
 		this.request = request;
 		this.response = response;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/events/RequestSucceded.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/events/RequestSucceded.java
@@ -3,12 +3,12 @@ package br.com.caelum.vraptor.events;
 import br.com.caelum.vraptor.http.MutableRequest;
 import br.com.caelum.vraptor.http.MutableResponse;
 
-public class EndRequest {
+public class RequestSucceded {
 
 	private final MutableRequest request;
 	private final MutableResponse response;
 
-	public EndRequest(MutableRequest request, MutableResponse response) {
+	public RequestSucceded(MutableRequest request, MutableResponse response) {
 		this.request = request;
 		this.response = response;
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIRequestFactories.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIRequestFactories.java
@@ -9,7 +9,7 @@ import javax.interceptor.Interceptor;
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpSession;
 
-import br.com.caelum.vraptor.events.NewRequest;
+import br.com.caelum.vraptor.events.RequestStarted;
 import br.com.caelum.vraptor.http.MutableRequest;
 import br.com.caelum.vraptor.http.MutableResponse;
 
@@ -18,33 +18,33 @@ import br.com.caelum.vraptor.http.MutableResponse;
 @Priority(Interceptor.Priority.LIBRARY_BEFORE)
 public class CDIRequestFactories {
 
-	private NewRequest newRequest;
+	private RequestStarted requestStarted;
 
-	public void setRequest(NewRequest info) {
-		this.newRequest = info;
+	public void setRequest(RequestStarted info) {
+		this.requestStarted = info;
 	}
 	
 	@Produces
 	@RequestScoped
 	public HttpSession getSession(){
-		return newRequest.getRequest().getSession();
+		return requestStarted.getRequest().getSession();
 	}
 	
 	@Produces
 	@RequestScoped
 	public MutableResponse getResponse(){
-		return newRequest.getResponse();
+		return requestStarted.getResponse();
 	}
 	
 	@Produces
 	@RequestScoped
 	public MutableRequest getRequest(){
-		return newRequest.getRequest();
+		return requestStarted.getRequest();
 	}
 	
 	@Produces
 	@RequestScoped
 	public FilterChain getChain(){
-		return newRequest.getChain();
+		return requestStarted.getChain();
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/DeserializingObserver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/DeserializingObserver.java
@@ -31,15 +31,15 @@ import org.slf4j.Logger;
 import br.com.caelum.vraptor.Consumes;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.core.MethodInfo;
-import br.com.caelum.vraptor.events.ReadyToExecuteMethod;
-import br.com.caelum.vraptor.events.StackStarting;
+import br.com.caelum.vraptor.events.MethodReady;
+import br.com.caelum.vraptor.events.InterceptorsReady;
 import br.com.caelum.vraptor.ioc.Container;
 import br.com.caelum.vraptor.serialization.Deserializer;
 import br.com.caelum.vraptor.serialization.Deserializers;
 import br.com.caelum.vraptor.view.Status;
 
 /**
- * <strong>Important</strong>: this class must observe {@link ReadyToExecuteMethod}
+ * <strong>Important</strong>: this class must observe {@link MethodReady}
  * because it is fired just before {@link ExecuteMethod} execution
  *
  * @author Lucas Cavalcanti
@@ -67,7 +67,7 @@ public class DeserializingObserver {
 		this.container = container;
 	}
 
-	public void deserializes(@Observes StackStarting event, HttpServletRequest request,
+	public void deserializes(@Observes InterceptorsReady event, HttpServletRequest request,
 			MethodInfo methodInfo, Status status) throws IOException {
 
 		ControllerMethod method = event.getControllerMethod();

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ExecuteMethod.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ExecuteMethod.java
@@ -34,9 +34,9 @@ import org.slf4j.Logger;
 import br.com.caelum.vraptor.InterceptionException;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.core.MethodInfo;
-import br.com.caelum.vraptor.events.EndOfInterceptorStack;
+import br.com.caelum.vraptor.events.InterceptorsExecuted;
 import br.com.caelum.vraptor.events.MethodExecuted;
-import br.com.caelum.vraptor.events.ReadyToExecuteMethod;
+import br.com.caelum.vraptor.events.MethodReady;
 import br.com.caelum.vraptor.validator.ValidationException;
 import br.com.caelum.vraptor.validator.Validator;
 
@@ -56,7 +56,7 @@ public class ExecuteMethod {
 	private final Validator validator;
 
 	private Event<MethodExecuted> methodExecutedEvent;
-	private Event<ReadyToExecuteMethod> readyToExecuteMethod;
+	private Event<MethodReady> methodReady;
 
 	/**
 	 * @deprecated CDI eyes only
@@ -67,17 +67,17 @@ public class ExecuteMethod {
 
 	@Inject
 	public ExecuteMethod(MethodInfo methodInfo, Validator validator, 
-			Event<MethodExecuted> methodExecutedEvent, Event<ReadyToExecuteMethod> readyToExecuteMethod) {
+			Event<MethodExecuted> methodExecutedEvent, Event<MethodReady> methodReady) {
 		this.methodInfo = methodInfo;
 		this.validator = validator;
 		this.methodExecutedEvent = methodExecutedEvent;
-		this.readyToExecuteMethod = readyToExecuteMethod;
+		this.methodReady = methodReady;
 	}
 
-	public void execute(@Observes EndOfInterceptorStack event) {
+	public void execute(@Observes InterceptorsExecuted event) {
 		try {
 			ControllerMethod method = event.getControllerMethod();
-			readyToExecuteMethod.fire(new ReadyToExecuteMethod(method));
+			methodReady.fire(new MethodReady(method));
 			Method reflectionMethod = method .getMethod();
 			Object[] parameters = methodInfo.getParametersValues();
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ForwardToDefaultView.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ForwardToDefaultView.java
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 
 import br.com.caelum.vraptor.Result;
-import br.com.caelum.vraptor.events.EndRequest;
+import br.com.caelum.vraptor.events.RequestSucceded;
 import br.com.caelum.vraptor.events.MethodExecuted;
 import br.com.caelum.vraptor.view.Results;
 
@@ -57,7 +57,7 @@ public class ForwardToDefaultView {
 		this.result = result;
 	}
 
-	public void forward(@Observes EndRequest event) {
+	public void forward(@Observes RequestSucceded event) {
 		if (result.used() || event.getResponse().isCommitted()) {
 			logger.debug("Request already dispatched and commited somewhere else, not forwarding.");
 			return;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParameterIncluder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParameterIncluder.java
@@ -7,7 +7,7 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
-import br.com.caelum.vraptor.events.ReadyToExecuteMethod;
+import br.com.caelum.vraptor.events.MethodReady;
 import br.com.caelum.vraptor.interceptor.IncludeParameters;
 import br.com.caelum.vraptor.validator.Outjector;
 
@@ -35,7 +35,7 @@ public class ParameterIncluder {
 		this.outjector = outjector;
 	}
 
-	public void include(@Observes ReadyToExecuteMethod event) {
+	public void include(@Observes MethodReady event) {
 		Method method = event.getControllerMethod().getMethod();
 		if (method.isAnnotationPresent(IncludeParameters.class)) {
 			outjector.get().outjectRequestMap();

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParametersInstantiator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParametersInstantiator.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 
 import br.com.caelum.vraptor.HeaderParam;
 import br.com.caelum.vraptor.core.MethodInfo;
-import br.com.caelum.vraptor.events.StackStarting;
+import br.com.caelum.vraptor.events.InterceptorsReady;
 import br.com.caelum.vraptor.http.MutableRequest;
 import br.com.caelum.vraptor.http.ParametersProvider;
 import br.com.caelum.vraptor.http.ValuedParameter;
@@ -81,7 +81,7 @@ public class ParametersInstantiator {
 		return methodInfo.getControllerMethod().getArity() > 0;
 	}
 
-	public void instantiate(@Observes StackStarting event) {
+	public void instantiate(@Observes InterceptorsReady event) {
 		if (isNotParameterless()) {
 			fixIndexedParameters(request);
 			addHeaderParametersToAttribute();

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/RequestHandlerObserver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/RequestHandlerObserver.java
@@ -31,8 +31,8 @@ import br.com.caelum.vraptor.controller.ControllerNotFoundHandler;
 import br.com.caelum.vraptor.controller.MethodNotAllowedHandler;
 import br.com.caelum.vraptor.core.InterceptorStack;
 import br.com.caelum.vraptor.events.ControllerFound;
-import br.com.caelum.vraptor.events.EndRequest;
-import br.com.caelum.vraptor.events.NewRequest;
+import br.com.caelum.vraptor.events.RequestSucceded;
+import br.com.caelum.vraptor.events.RequestStarted;
 import br.com.caelum.vraptor.http.UrlToControllerTranslator;
 import br.com.caelum.vraptor.http.route.ControllerNotFoundException;
 import br.com.caelum.vraptor.http.route.MethodNotAllowedException;
@@ -57,7 +57,7 @@ public class RequestHandlerObserver {
 	private final Event<ControllerFound> controllerFoundEvent;
 	private final InterceptorStack interceptorStack;
 
-	private Event<EndRequest> endRequestEvent;
+	private Event<RequestSucceded> endRequestEvent;
 
 	/**
 	 * @deprecated CDI eyes only
@@ -70,7 +70,7 @@ public class RequestHandlerObserver {
 	public RequestHandlerObserver(UrlToControllerTranslator translator,
 			ControllerNotFoundHandler controllerNotFoundHandler, MethodNotAllowedHandler methodNotAllowedHandler,
 			Event<ControllerFound> controllerFoundEvent, 
-			Event<EndRequest> endRequestEvent, 
+			Event<RequestSucceded> endRequestEvent, 
 			InterceptorStack interceptorStack) {
 		this.translator = translator;
 		this.methodNotAllowedHandler = methodNotAllowedHandler;
@@ -80,13 +80,13 @@ public class RequestHandlerObserver {
 		this.interceptorStack = interceptorStack;
 	}
 
-	public void handle(@Observes NewRequest event, CDIRequestFactories factories) {
+	public void handle(@Observes RequestStarted event, CDIRequestFactories factories) {
 		try {
 			factories.setRequest(event);
 			ControllerMethod method = translator.translate(event.getRequest());
 			controllerFoundEvent.fire(new ControllerFound(method));
 			interceptorStack.start();
-			endRequestEvent.fire(new EndRequest(event.getRequest(), event.getResponse()));
+			endRequestEvent.fire(new RequestSucceded(event.getRequest(), event.getResponse()));
 		} catch (ControllerNotFoundException e) {
 			controllerNotFoundHandler.couldntFind(event.getChain(), event.getRequest(), event.getResponse());
 		} catch (MethodNotAllowedException e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MethodValidator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MethodValidator.java
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import br.com.caelum.vraptor.controller.ControllerInstance;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.core.MethodInfo;
-import br.com.caelum.vraptor.events.ReadyToExecuteMethod;
+import br.com.caelum.vraptor.events.MethodReady;
 import br.com.caelum.vraptor.http.ValuedParameter;
 import br.com.caelum.vraptor.validator.SimpleMessage;
 import br.com.caelum.vraptor.validator.Validator;
@@ -88,7 +88,7 @@ public class MethodValidator {
 		return descriptor != null && descriptor.hasConstrainedParameters();
 	}
 
-	public void validate(@Observes ReadyToExecuteMethod event, ControllerInstance controllerInstance,
+	public void validate(@Observes MethodReady event, ControllerInstance controllerInstance,
 			MethodInfo methodInfo, Validator validator) {
 		ControllerMethod controllerMethod = event.getControllerMethod();
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/core/DefaultInterceptorStackTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/core/DefaultInterceptorStackTest.java
@@ -16,8 +16,8 @@ import org.mockito.stubbing.Answer;
 import br.com.caelum.vraptor.controller.ControllerInstance;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.controller.DefaultControllerInstance;
-import br.com.caelum.vraptor.events.EndOfInterceptorStack;
-import br.com.caelum.vraptor.events.StackStarting;
+import br.com.caelum.vraptor.events.InterceptorsExecuted;
+import br.com.caelum.vraptor.events.InterceptorsReady;
 import br.com.caelum.vraptor.util.test.MockInstanceImpl;
 
 public class DefaultInterceptorStackTest {
@@ -27,8 +27,8 @@ public class DefaultInterceptorStackTest {
 	private @Mock Object controller;
 	private @Mock InterceptorStackHandlersCache cache;
 	private @Mock ControllerMethod controllerMethod;
-	private @Mock Event<EndOfInterceptorStack> event;
-	private @Mock Event<StackStarting> stackStartingEvent;
+	private @Mock Event<InterceptorsReady> interceptorsReadyEvent;
+	private @Mock Event<InterceptorsExecuted> interceptorsExecutedEvent;
 	private @Mock InterceptorHandler handler;
 	
 	private DefaultInterceptorStack stack;
@@ -38,7 +38,7 @@ public class DefaultInterceptorStackTest {
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
 		controllerInstance = new DefaultControllerInstance(controller);
-		stack = new DefaultInterceptorStack(cache, new MockInstanceImpl<>(controllerMethod), new MockInstanceImpl<>(controllerInstance), event, stackStartingEvent);
+		stack = new DefaultInterceptorStack(cache, new MockInstanceImpl<>(controllerMethod), new MockInstanceImpl<>(controllerInstance), interceptorsExecutedEvent, interceptorsReadyEvent);
 		LinkedList<InterceptorHandler> handlers = new LinkedList<>();
 		handlers.add(handler);
 		
@@ -49,7 +49,7 @@ public class DefaultInterceptorStackTest {
 	public void firesStartEventOnStart() throws Exception {
 		stack.start();
 		
-		verify(stackStartingEvent).fire(any(StackStarting.class));
+		verify(interceptorsReadyEvent).fire(any(InterceptorsReady.class));
 	}
 	
 	@Test
@@ -63,7 +63,7 @@ public class DefaultInterceptorStackTest {
 	public void doesntFireEndOfStackIfTheInterceptorsDontContinueTheStack() throws Exception {	
 		stack.start();
 		
-		verify(event, never()).fire(any(EndOfInterceptorStack.class));
+		verify(interceptorsExecutedEvent, never()).fire(any(InterceptorsExecuted.class));
 	}
 	
 	@Test
@@ -72,7 +72,7 @@ public class DefaultInterceptorStackTest {
 		
 		stack.start();
 		
-		verify(event).fire(any(EndOfInterceptorStack.class));
+		verify(interceptorsExecutedEvent).fire(any(InterceptorsExecuted.class));
 	}
 
 	private Answer<Void> callNext() {

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/DeserializingObserverTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/DeserializingObserverTest.java
@@ -19,7 +19,7 @@ import br.com.caelum.vraptor.Consumes;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.controller.DefaultControllerMethod;
 import br.com.caelum.vraptor.core.MethodInfo;
-import br.com.caelum.vraptor.events.StackStarting;
+import br.com.caelum.vraptor.events.InterceptorsReady;
 import br.com.caelum.vraptor.factory.Factories;
 import br.com.caelum.vraptor.ioc.Container;
 import br.com.caelum.vraptor.serialization.Deserializer;
@@ -63,7 +63,7 @@ public class DeserializingObserverTest {
 
 	@Test
 	public void shouldOnlyAcceptMethodsWithConsumesAnnotation() throws Exception {
-		observer.deserializes(new StackStarting(doesntConsume), request, methodInfo, status);
+		observer.deserializes(new InterceptorsReady(doesntConsume), request, methodInfo, status);
 		verifyZeroInteractions(request);
 	}
 
@@ -71,7 +71,7 @@ public class DeserializingObserverTest {
 	public void willSetHttpStatusCode415IfTheControllerMethodDoesNotSupportTheGivenMediaTypes() throws Exception {
 		when(request.getContentType()).thenReturn("image/jpeg");
 
-		observer.deserializes(new StackStarting(consumeXml), request, methodInfo, status);
+		observer.deserializes(new InterceptorsReady(consumeXml), request, methodInfo, status);
 
 		verify(status).unsupportedMediaType("Request with media type [image/jpeg]. Expecting one of [application/xml].");
 	}
@@ -81,7 +81,7 @@ public class DeserializingObserverTest {
 		when(request.getContentType()).thenReturn("application/xml");
 		when(deserializers.deserializerFor("application/xml", container)).thenReturn(null);
 
-		observer.deserializes(new StackStarting(consumeXml), request, methodInfo, status);
+		observer.deserializes(new InterceptorsReady(consumeXml), request, methodInfo, status);
 
 		verify(status).unsupportedMediaType("Unable to handle media type [application/xml]: no deserializer found.");
 	}
@@ -96,7 +96,7 @@ public class DeserializingObserverTest {
 		when(deserializer.deserialize(null, consumeXml)).thenReturn(new Object[] {"abc", "def"});
 		when(deserializers.deserializerFor("application/xml", container)).thenReturn(deserializer);
 
-		observer.deserializes(new StackStarting(consumeXml), request, methodInfo, status);
+		observer.deserializes(new InterceptorsReady(consumeXml), request, methodInfo, status);
 
 		assertEquals(methodInfo.getValuedParameters()[0].getValue(), "abc");
 		assertEquals(methodInfo.getValuedParameters()[1].getValue(), "def");
@@ -112,7 +112,7 @@ public class DeserializingObserverTest {
 		when(deserializer.deserialize(null, consumeXml)).thenReturn(new Object[] {"abc", "def"});
 		when(deserializers.deserializerFor("application/xml", container)).thenReturn(deserializer);
 
-		observer.deserializes(new StackStarting(consumeXml), request, methodInfo, status);
+		observer.deserializes(new InterceptorsReady(consumeXml), request, methodInfo, status);
 
 		assertEquals(methodInfo.getValuedParameters()[0].getValue(), "abc");
 		assertEquals(methodInfo.getValuedParameters()[1].getValue(), "def");
@@ -131,7 +131,7 @@ public class DeserializingObserverTest {
 		when(deserializer.deserialize(null, consumesAnything)).thenReturn(new Object[] {"abc", "def"});
 
 		when(deserializers.deserializerFor("application/xml", container)).thenReturn(deserializer);
-		observer.deserializes(new StackStarting(consumesAnything), request, methodInfo, status);
+		observer.deserializes(new InterceptorsReady(consumesAnything), request, methodInfo, status);
 
 		assertEquals(methodInfo.getValuedParameters()[0].getValue(), "abc");
 		assertEquals(methodInfo.getValuedParameters()[1].getValue(), "def");
@@ -149,7 +149,7 @@ public class DeserializingObserverTest {
 		when(deserializer.deserialize(null, consumeXml)).thenReturn(new Object[] {null, "deserialized"});
 
 		when(deserializers.deserializerFor("application/xml", container)).thenReturn(deserializer);
-		observer.deserializes(new StackStarting(consumeXml), request, methodInfo, status);
+		observer.deserializes(new InterceptorsReady(consumeXml), request, methodInfo, status);
 
 		assertEquals(methodInfo.getValuedParameters()[0].getValue(), "original1");
 		assertEquals(methodInfo.getValuedParameters()[1].getValue(), "deserialized");
@@ -162,6 +162,6 @@ public class DeserializingObserverTest {
 
 		final Deserializer deserializer = mock(Deserializer.class);
 		when(deserializers.deserializerFor("application/xml", container)).thenReturn(deserializer);
-		observer.deserializes(new StackStarting(consumeXml), request, methodInfo, status);
+		observer.deserializes(new InterceptorsReady(consumeXml), request, methodInfo, status);
 	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/ExecuteMethodTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/ExecuteMethodTest.java
@@ -37,9 +37,9 @@ import br.com.caelum.vraptor.InterceptionException;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.controller.DefaultControllerMethod;
 import br.com.caelum.vraptor.core.MethodInfo;
-import br.com.caelum.vraptor.events.EndOfInterceptorStack;
+import br.com.caelum.vraptor.events.InterceptorsExecuted;
 import br.com.caelum.vraptor.events.MethodExecuted;
-import br.com.caelum.vraptor.events.ReadyToExecuteMethod;
+import br.com.caelum.vraptor.events.MethodReady;
 import br.com.caelum.vraptor.interceptor.DogAlike;
 import br.com.caelum.vraptor.validator.Message;
 import br.com.caelum.vraptor.validator.ValidationException;
@@ -50,7 +50,7 @@ public class ExecuteMethodTest {
 	@Mock private MethodInfo methodInfo;
 	@Mock private Validator validator;
 	@Mock private Event<MethodExecuted> methodEvecutedEvent;
-	@Mock private Event<ReadyToExecuteMethod> readyToExecuteMethodEvent;
+	@Mock private Event<MethodReady> readyToExecuteMethodEvent;
 	private ExecuteMethod observer;
 
 	@Before
@@ -64,7 +64,7 @@ public class ExecuteMethodTest {
 		ControllerMethod method = new DefaultControllerMethod(null, DogAlike.class.getMethod("bark"));
 		DogAlike auau = mock(DogAlike.class);
 		when(methodInfo.getParametersValues()).thenReturn(new Object[0]);
-		observer.execute(new EndOfInterceptorStack(method, auau));
+		observer.execute(new InterceptorsExecuted(method, auau));
 		verify(auau).bark();
 	}
 
@@ -73,7 +73,7 @@ public class ExecuteMethodTest {
 		ControllerMethod method = new DefaultControllerMethod(null, DogAlike.class.getMethod("bark", int.class));
 		DogAlike auau = mock(DogAlike.class);
 		when(methodInfo.getParametersValues()).thenReturn(new Object[] { 3 });
-		observer.execute(new EndOfInterceptorStack(method, auau));
+		observer.execute(new InterceptorsExecuted(method, auau));
 		verify(auau).bark(3);
 	}
 
@@ -90,7 +90,7 @@ public class ExecuteMethodTest {
 		ControllerMethod method = new DefaultControllerMethod(null, XController.class.getMethod("method", Object.class));
 		final XController controller = new XController();
 		when(methodInfo.getParametersValues()).thenReturn(new Object[] { "string" });
-		observer.execute(new EndOfInterceptorStack(method, controller));
+		observer.execute(new InterceptorsExecuted(method, controller));
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class ExecuteMethodTest {
 		ControllerMethod method = new DefaultControllerMethod(null, XController.class.getMethod("method", Object.class));
 		final XController controller = new XController();
 		when(methodInfo.getParametersValues()).thenReturn(new Object[] { null });
-		observer.execute(new EndOfInterceptorStack(method, controller));
+		observer.execute(new InterceptorsExecuted(method, controller));
 		verify(methodInfo).setResult(null);
 	}
 
@@ -110,7 +110,7 @@ public class ExecuteMethodTest {
 		when(methodInfo.getParametersValues()).thenReturn(new Object[0]);
 		doThrow(new ValidationException(Collections.<Message> emptyList())).when(validator).onErrorUse(nothing());
 		when(validator.hasErrors()).thenReturn(true);
-		observer.execute(new EndOfInterceptorStack(method, controller));
+		observer.execute(new InterceptorsExecuted(method, controller));
 	}
 
 	@Test(expected=InterceptionException.class)
@@ -120,7 +120,7 @@ public class ExecuteMethodTest {
 		final AnyController controller = new AnyController(validator);
 		when(methodInfo.getParametersValues()).thenReturn(new Object[0]);
 		when(validator.hasErrors()).thenReturn(true);
-		observer.execute(new EndOfInterceptorStack(method, controller));
+		observer.execute(new InterceptorsExecuted(method, controller));
 	}
 
 	public static class AnyController {

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/ForwardToDefaultViewTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/ForwardToDefaultViewTest.java
@@ -30,7 +30,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import br.com.caelum.vraptor.Result;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.core.MethodInfo;
-import br.com.caelum.vraptor.events.EndRequest;
+import br.com.caelum.vraptor.events.RequestSucceded;
 import br.com.caelum.vraptor.events.MethodExecuted;
 import br.com.caelum.vraptor.http.MutableRequest;
 import br.com.caelum.vraptor.http.MutableResponse;
@@ -55,14 +55,14 @@ public class ForwardToDefaultViewTest {
 	@Test
 	public void doesNothingIfResultWasAlreadyUsed() {
 		when(result.used()).thenReturn(true);
-		interceptor.forward(new EndRequest(request, response));
+		interceptor.forward(new RequestSucceded(request, response));
 		verify(result, never()).use(PageResult.class);
 	}
 	
 	@Test
 	public void doesNothingIfResponseIsCommited() {
 		when(response.isCommitted()).thenReturn(true);
-		interceptor.forward(new EndRequest(request, response));
+		interceptor.forward(new RequestSucceded(request, response));
 		verify(result, never()).use(PageResult.class);
 	}
 
@@ -70,7 +70,7 @@ public class ForwardToDefaultViewTest {
 	public void shouldForwardToViewWhenResultWasNotUsed() {
 		when(result.used()).thenReturn(false);
 		when(result.use(PageResult.class)).thenReturn(new MockedPage());
-		interceptor.forward(new EndRequest(request, response));
+		interceptor.forward(new RequestSucceded(request, response));
 		verify(result).use(PageResult.class);
 	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/ParametersInstantiatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/observer/ParametersInstantiatorTest.java
@@ -44,7 +44,7 @@ import br.com.caelum.vraptor.HeaderParam;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.controller.DefaultControllerMethod;
 import br.com.caelum.vraptor.core.MethodInfo;
-import br.com.caelum.vraptor.events.StackStarting;
+import br.com.caelum.vraptor.events.InterceptorsReady;
 import br.com.caelum.vraptor.factory.Factories;
 import br.com.caelum.vraptor.http.MutableRequest;
 import br.com.caelum.vraptor.http.ParametersProvider;
@@ -98,7 +98,7 @@ public class ParametersInstantiatorTest {
 		methodInfo.setControllerMethod(method);
 
 		verifyNoMoreInteractions(parametersProvider, validator, request, flash);
-		instantiator.instantiate(new StackStarting(method));
+		instantiator.instantiate(new InterceptorsReady(method));
 	}
 
 	@Test
@@ -108,7 +108,7 @@ public class ParametersInstantiatorTest {
 
 		when(parametersProvider.getParametersFor(otherMethod, errors)).thenReturn(values);
 
-		instantiator.instantiate(new StackStarting(otherMethod));
+		instantiator.instantiate(new InterceptorsReady(otherMethod));
 
 		verify(validator).addAll(Collections.<Message> emptyList());
 
@@ -122,7 +122,7 @@ public class ParametersInstantiatorTest {
 		when(parametersProvider.getParametersFor(otherMethod, errors)).thenReturn(new Object[1]);
 
 		methodInfo.setControllerMethod(otherMethod);
-		instantiator.instantiate(new StackStarting(otherMethod));
+		instantiator.instantiate(new InterceptorsReady(otherMethod));
 
 		verify(request).setParameter("someParam[0].id", "one");
 		verify(request).setParameter("someParam[1].id", "two");
@@ -139,7 +139,7 @@ public class ParametersInstantiatorTest {
 		when(request.getParameterNames()).thenReturn(enumeration(asList("someParam.class.id", "unrelatedParam")));
 		when(request.getParameterValues("someParam.class.id")).thenReturn(new String[] {"whatever"});
 
-		instantiator.instantiate(new StackStarting(otherMethod));
+		instantiator.instantiate(new InterceptorsReady(otherMethod));
 	}
 
 	@Test
@@ -149,7 +149,7 @@ public class ParametersInstantiatorTest {
 
 		when(flash.consumeParameters(otherMethod)).thenReturn(values);
 
-		instantiator.instantiate(new StackStarting(otherMethod));
+		instantiator.instantiate(new InterceptorsReady(otherMethod));
 
 		verify(validator).addAll(Collections.<Message>emptyList());
 		verify(parametersProvider, never()).getParametersFor(otherMethod, errors);
@@ -164,7 +164,7 @@ public class ParametersInstantiatorTest {
 		when(parametersProvider.getParametersFor(otherMethod, errors))
 			.thenAnswer(addErrorsToListAndReturn(new Object[] { 0 }, "error1"));
 
-		instantiator.instantiate(new StackStarting(otherMethod));
+		instantiator.instantiate(new InterceptorsReady(otherMethod));
 
 		verify(validator).addAll(errors);
 		assertEquals(methodInfo.getValuedParameters()[0].getValue(), 0);
@@ -180,7 +180,7 @@ public class ParametersInstantiatorTest {
 		when(request.getHeader("X-MyApp-Password")).thenReturn("123");
 		when(parametersProvider.getParametersFor(controllerMethod, errors)).thenReturn(values);
 
-		instantiator.instantiate(new StackStarting(controllerMethod));
+		instantiator.instantiate(new InterceptorsReady(controllerMethod));
 
 		verify(request).setParameter("password", "123");
 		verify(validator).addAll(Collections.<Message> emptyList());
@@ -192,7 +192,7 @@ public class ParametersInstantiatorTest {
 		when(parametersProvider.getParametersFor(otherMethod, errors)).thenReturn(values);
 
 		methodInfo.setControllerMethod(otherMethod);
-		instantiator.instantiate(new StackStarting(otherMethod));
+		instantiator.instantiate(new InterceptorsReady(otherMethod));
 
 		verify(request, never()).setParameter(anyString(), anyString());
 		verify(validator).addAll(Collections.<Message>emptyList());

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MethodValidatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MethodValidatorTest.java
@@ -22,7 +22,7 @@ import org.mockito.MockitoAnnotations;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.controller.DefaultControllerInstance;
 import br.com.caelum.vraptor.core.MethodInfo;
-import br.com.caelum.vraptor.events.ReadyToExecuteMethod;
+import br.com.caelum.vraptor.events.MethodReady;
 import br.com.caelum.vraptor.factory.Factories;
 import br.com.caelum.vraptor.util.test.MockValidator;
 import br.com.caelum.vraptor.validator.beanvalidation.MessageInterpolatorFactory;
@@ -68,14 +68,14 @@ public class MethodValidatorTest {
 		methodInfo.setControllerMethod(withConstraint);
 
 		DefaultControllerInstance controller = spy(instance);
-		getMethodValidator().validate(new ReadyToExecuteMethod(withConstraint), controller, methodInfo, validator);
+		getMethodValidator().validate(new MethodReady(withConstraint), controller, methodInfo, validator);
 		verify(controller).getController();
 	}
 
 	@Test
 	public void shouldNotAcceptIfMethodHasConstraint() {
 		DefaultControllerInstance controller = spy(instance);
-		getMethodValidator().validate(new ReadyToExecuteMethod(withoutConstraint), controller, methodInfo, validator);
+		getMethodValidator().validate(new MethodReady(withoutConstraint), controller, methodInfo, validator);
 		verify(controller, never()).getController();
 	}
 
@@ -83,7 +83,7 @@ public class MethodValidatorTest {
 	public void shouldValidateMethodWithConstraint() throws Exception {
 		methodInfo.setControllerMethod(withConstraint);
 
-		getMethodValidator().validate(new ReadyToExecuteMethod(withConstraint), instance, methodInfo, validator);
+		getMethodValidator().validate(new MethodReady(withConstraint), instance, methodInfo, validator);
 		assertThat(validator.getErrors(), hasSize(1));
 		assertThat(validator.getErrors().get(0).getCategory(), is("withConstraint.email"));
 	}


### PR DESCRIPTION
new names:

``` java
VRaptorInitialized

RequestStarted
RequestSucceeded  // we could have RequestFailed and RequestComplete later

ControllerFound
ControllerNotFound

InterceptorsReady
InterceptorsExecuted

MethodReady
MethodExecuted
```
