### PR TITLE
Moving EmptyBundle to core package like SafeResourceBundle

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/JstlLocalization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/JstlLocalization.java
@@ -31,6 +31,9 @@ import javax.servlet.jsp.jstl.fmt.LocalizationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import br.com.caelum.vraptor.util.EmptyBundle;
+import br.com.caelum.vraptor.util.SafeResourceBundle;
+
 import com.google.common.base.Strings;
 
 /**

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/EmptyBundle.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/EmptyBundle.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package br.com.caelum.vraptor.core;
+package br.com.caelum.vraptor.util;
 
 import java.util.ListResourceBundle;
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/SafeResourceBundle.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/SafeResourceBundle.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package br.com.caelum.vraptor.core;
+package br.com.caelum.vraptor.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/util/SafeResourceBundleTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/util/SafeResourceBundleTest.java
@@ -1,4 +1,4 @@
-package br.com.caelum.vraptor.core;
+package br.com.caelum.vraptor.util;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -8,6 +8,8 @@ import java.util.PropertyResourceBundle;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import br.com.caelum.vraptor.util.SafeResourceBundle;
 
 public class SafeResourceBundleTest {
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/DefaultValidatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/DefaultValidatorTest.java
@@ -45,9 +45,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import br.com.caelum.vraptor.Controller;
 import br.com.caelum.vraptor.Result;
-import br.com.caelum.vraptor.core.SafeResourceBundle;
 import br.com.caelum.vraptor.proxy.JavassistProxifier;
 import br.com.caelum.vraptor.proxy.Proxifier;
+import br.com.caelum.vraptor.util.SafeResourceBundle;
 import br.com.caelum.vraptor.util.test.MockResult;
 import br.com.caelum.vraptor.view.DefaultValidationViewsFactory;
 import br.com.caelum.vraptor.view.LogicResult;


### PR DESCRIPTION
Because these classes have the same goal, and it's better to live in the same package.
