### PR TITLE
Allow method chain for Validator methods

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/test/MockValidator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/test/MockValidator.java
@@ -71,10 +71,11 @@ public class MockValidator extends AbstractValidator {
 	}
 
 	@Override
-	public <T> void addAll(Set<ConstraintViolation<T>> errors) {
+	public <T> Validator addAll(Set<ConstraintViolation<T>> errors) {
 		for (ConstraintViolation<T> v : errors) {
 			add(new SimpleMessage(v.getPropertyPath().toString(), v.getMessage()));
 		}
+		return this;
 	}
 
 	@Override
@@ -86,15 +87,17 @@ public class MockValidator extends AbstractValidator {
 	}
 
 	@Override
-	public void addAll(Collection<? extends Message> messages) {
+	public Validator addAll(Collection<? extends Message> messages) {
 		for(Message message: messages) {
 			add(message);
 		}
+		return this;
 	}
 
 	@Override
-	public void add(Message message) {
+	public Validator add(Message message) {
 		errors.add(message);
+		return this;
 	}
 
 	@Override

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/DefaultValidator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/DefaultValidator.java
@@ -97,13 +97,29 @@ public class DefaultValidator extends AbstractValidator {
 		return this;
 	}
 
-	public <T> void addAll(Set<ConstraintViolation<T>>  errors) {
+	@Override
+	public Validator addAll(Collection<? extends Message> messages) {
+		for (Message message : messages) {
+			add(message);
+		}
+		return this;
+	}
+
+	@Override
+	public Validator add(Message message) {
+		message.setBundle(bundle);
+		errors.add(message);
+		return this;
+	}
+
+	public <T> Validator addAll(Set<ConstraintViolation<T>>  errors) {
 		for (ConstraintViolation<T> v : errors) {
 			String msg = interpolator.interpolate(v.getMessageTemplate(), new BeanValidatorContext(v), locale);
 			String category = v.getPropertyPath().toString();
 			add(new SimpleMessage(category, msg));
 			logger.debug("added message {}={} for contraint violation", category, msg);
 		}
+		return this;
 	}
 
 	@Override
@@ -117,19 +133,6 @@ public class DefaultValidator extends AbstractValidator {
 		
 		logger.debug("there are errors on result: {}", errors);
 		return viewsFactory.instanceFor(view, errors);
-	}
-
-	@Override
-	public void addAll(Collection<? extends Message> messages) {
-		for (Message message : messages) {
-			add(message);
-		}
-	}
-
-	@Override
-	public void add(Message message) {
-		message.setBundle(bundle);
-		errors.add(message);
 	}
 
 	@Override

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/Validator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/Validator.java
@@ -51,23 +51,22 @@ public interface Validator {
 	Validator validate(Object object, Class<?>... groups);
 
 	/**
-	 * If validator has errors, you can use this method to define what to do. WARN: this method don't stop the flow.
-	 * @param view
-	 * @return
-	 */
-	<T extends View> T onErrorUse(Class<T> view);
-
-	/**
-	 * Adds the list of messages.
-	 * @param messages
-	 */
-	void addAll(Collection<? extends Message> messages);
-
-	/**
-	 * Adds the message.
+	 * Adds the message and return the same validator instance.
 	 * @param message
 	 */
-	void add(Message message);
+	Validator add(Message message);
+
+	/**
+	 * Adds the list of messages and return the same validator instance.
+	 * @param messages
+	 */
+	Validator addAll(Collection<? extends Message> messages);
+
+	/**
+	 * Add messages from bean validation translating to vraptor {@link Message}.
+	 * @param errors
+	 */
+	<T> Validator addAll(Set<ConstraintViolation<T>> errors);
 
 	/**
 	 * Returns a list of errors.
@@ -80,6 +79,13 @@ public interface Validator {
 	 * @return
 	 */
 	boolean hasErrors();
+
+	/**
+	 * If validator has errors, you can use this method to define what to do. WARN: this method don't stop the flow.
+	 * @param view
+	 * @return
+	 */
+	<T extends View> T onErrorUse(Class<T> view);
 
 	/**
 	 * Shortcut for <br>
@@ -130,11 +136,5 @@ public interface Validator {
 	 * the actual validation errors list will be used.
 	 */
 	void onErrorSendBadRequest();
-
-	/**
-	 * Add messages from bean validation translating to vraptor {@link Message}.
-	 * @param errors
-	 */
-	<T> void addAll(Set<ConstraintViolation<T>> errors);
 
 }


### PR DESCRIPTION
With this minor change, users can use something like this:

``` java
validator.add(firstError)
    .validate(myBadBean)
    .onErrorUse(...);
```
