### PR TITLE
Adding mocked resource bundle

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/test/MockResourceBundle.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/test/MockResourceBundle.java
@@ -1,0 +1,31 @@
+package br.com.caelum.vraptor.util.test;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.ResourceBundle;
+
+/**
+ * Mocked resource bundle that only returns the own key. Can be useful if you need to test without load a
+ * resource bundle.
+ * 
+ * @author Otávio Scherer Garcia
+ * @since 4.0.0
+ */
+public class MockResourceBundle extends ResourceBundle {
+
+	/**
+	 * Returns nothing.
+	 */
+	@Override
+	public Enumeration<String> getKeys() {
+		return Collections.emptyEnumeration();
+	}
+
+	/**
+	 * Return the same key as value.
+	 */
+	@Override
+	protected Object handleGetObject(String key) {
+		return key;
+	}
+}


### PR DESCRIPTION
Mocked resource bundle that only returns the own key. Can be useful if you need to test without load a resource bundle. At this time is used in time converters to test without load a resource bundle.
