### PR TITLE
using artifacts from weld instead of weld-servlet

### DIFF
--- a/vraptor-blank-project/pom.xml
+++ b/vraptor-blank-project/pom.xml
@@ -10,6 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<weld.version>2.1.2.Final</weld.version>
 	</properties>
 
 	<dependencies>
@@ -21,9 +22,15 @@
 
 		<dependency>
 			<groupId>org.jboss.weld.servlet</groupId>
-			<artifactId>weld-servlet</artifactId>
-			<version>2.1.2.Final</version>
+			<artifactId>weld-servlet-core</artifactId>
+			<version>${weld.version}</version>
 		</dependency>
+		
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+            <version>${weld.version}</version>
+        </dependency>
 
 		<dependency>
 		    <groupId>javax.el</groupId>

--- a/vraptor-musicjungle/pom.xml
+++ b/vraptor-musicjungle/pom.xml
@@ -10,6 +10,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<weld.version>2.1.2.Final</weld.version>
 	</properties>
 
 	<dependencies>
@@ -32,10 +33,16 @@
 		</dependency>
 
 		<dependency>
-		    <groupId>org.jboss.weld.servlet</groupId>
-		    <artifactId>weld-servlet</artifactId>
-		    <version>2.1.2.Final</version>
+			<groupId>org.jboss.weld.servlet</groupId>
+			<artifactId>weld-servlet-core</artifactId>
+			<version>${weld.version}</version>
 		</dependency>
+		
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+            <version>${weld.version}</version>
+        </dependency>
 
 		<dependency>
 			<groupId>commons-fileupload</groupId>


### PR DESCRIPTION
Using weld-servlet-core and weld-core-impl instead o weld-servlet to avoid classloader problems. If you accept this, I'll update de docs...
