### PR TITLE
fixing weld dependencies in vraptor-site

### DIFF
--- a/vraptor-site/content/pt/docs/dependencias-e-pre-requisitos.html
+++ b/vraptor-site/content/pt/docs/dependencias-e-pre-requisitos.html
@@ -77,6 +77,12 @@ E se você utiliza um Servler Container (como o Tomcat ou Jetty) você precisa a
 </dependency>
 ~~~
 
+**Observação importante**: evite usar o artefato org.jboss.weld.servlet:weld-servlet. Este    
+artefato contém todas as classes necessárias, porém contém mais classes do que é   
+preciso para subir a sua aplicação. Em particular, o weld-servlet contém uma **cópia** de  
+todo o código do guava, que já é dependência do VRaptor, o que pode gerar conflitos    
+entre as classes dos dois artefatos (o terrível class loader hell).
+
 
 ## Logging
 


### PR DESCRIPTION
I think it's important to warn users about this dependencies, because this modification https://github.com/csokol/vraptor4/commit/4ce62404c740837164dac1a5afb980a39534b44b
is incompatible with the guava embedded in the weld-servlet artifact.
