### PR TITLE
now plugin links are clickable

### DIFF
--- a/vraptor-site/content/en/docs/plugins.html
+++ b/vraptor-site/content/en/docs/plugins.html
@@ -35,7 +35,7 @@ The plugin doesn't delivery any provider. So you need to declare your prefered p
 </dependency>
 ~~~
 
-Plugin page at Gihub: https://github.com/caelum/vraptor-jpa
+[Plugin page at Gihub](https://github.com/caelum/vraptor-jpa).
 
 
 ##VRaptor Hibernate
@@ -53,7 +53,7 @@ If you want to use, you need only copy the jars for your app. Or if your project
 </dependency>
 ~~~ 
 
-Plugin page at Gihub: https://github.com/caelum/vraptor-hibernate
+[Plugin page at Gihub](https://github.com/caelum/vraptor-hibernate).
 
 
 ##Simple mail
@@ -69,7 +69,7 @@ Allow you to send e-mail in an easy way.
 </dependency>
 ~~~ 
 
-Plugin page at Gihub: https://github.com/caelum/vraptor-simplemail
+[Plugin page at Gihub](https://github.com/caelum/vraptor-simplemail).
 
 
 ##VRaptor Shiro
@@ -85,7 +85,7 @@ O VRaptor Apache Shiro Plugin provê suporte a autenticação, autorização, cr
 </dependency>
 ~~~ 
 
-Plugin page at Gihub: https://github.com/dipold/vraptor-shiro
+[Plugin page at Gihub](https://github.com/dipold/vraptor-shiro).
 
 
 ## Joda-time
@@ -101,7 +101,7 @@ Joda-time is a pretty API to work with date and time. To use joda-time you need 
 </dependency>
 ~~~
 
-Plugin page at Gihub: https://github.com/caelum/vraptor-time-converters
+[Plugin page at Gihub](https://github.com/caelum/vraptor-time-converters).
 
 
 ## New Java Date and Time API
@@ -117,7 +117,7 @@ If you are using Java 8, you can use the new API under the package `java.time`. 
 </dependency>
 ~~~
 
-Plugin page at Gihub: https://github.com/caelum/vraptor-time-converters
+[Plugin page at Gihub](https://github.com/caelum/vraptor-time-converters).
 
 ##VRaptor Error-Control
 
@@ -132,7 +132,7 @@ Allows you to real time control error messages sending them by email.
 </dependency>
 ~~~ 
 
-Plugin page at Gihub: https://github.com/caelum/vraptor-error-control
+[Plugin page at Gihub](https://github.com/caelum/vraptor-error-control).
 
 ##VRaptor Brutauth
 
@@ -147,7 +147,7 @@ Easy way to verify permission to access(authorization) a specific controller act
 </dependency>
 ~~~ 
 
-Plugin page at Gihub: https://github.com/leonardowolter/vraptor-brutauth
+[Plugin page at Gihub](https://github.com/leonardowolter/vraptor-brutauth).
 
 ##VRaptor QuartzJob
 
@@ -162,7 +162,7 @@ A simple Quartz scheduler
 </dependency>
 ~~~ 
 
-Plugin page at Gihub: http://github.com/caelum/vraptor-quartzjob
+[Plugin page at Gihub](http://github.com/caelum/vraptor-quartzjob).
 
 ##VRaptor Freemarker
 
@@ -177,7 +177,7 @@ Help you to render freemarker templates.
 </dependency>
 ~~~ 
 
-Plugin page at Gihub: http://github.com/caelum/vraptor-freemarker
+[Plugin page at Gihub](http://github.com/caelum/vraptor-freemarker).
 
 ##VRaptor Dash
 
@@ -192,7 +192,7 @@ A dashboard with several tools for your vraptor project.
 </dependency>
 ~~~ 
 
-Plugin page at Gihub: http://github.com/caelum/vraptor-dash
+[Plugin page at Gihub](http://github.com/caelum/vraptor-dash).
 
 
 ##VRaptor Authz
@@ -208,11 +208,9 @@ An alternative for access control (authorization) of your controller methods.
 </dependency>
 ~~~ 
 
-Plugin page at Gihub: https://github.com/Turini/vraptor-authz
+[Plugin page at Gihub](https://github.com/Turini/vraptor-authz).
 
 
 ##VRaptor contrib
 
-https://github.com/caelum/vraptor-contrib
-
-You can found some plugins made by our users.
+You can found some plugins made by our users on [vraptor-contrib](https://github.com/caelum/vraptor-contrib).

--- a/vraptor-site/content/pt/docs/plugins.html
+++ b/vraptor-site/content/pt/docs/plugins.html
@@ -35,7 +35,7 @@ O plugin não possui nenhum provider. Com isso é necessário que você declare 
 </dependency>
 ~~~
 
-Plugin no Gihub: https://github.com/caelum/vraptor-jpa
+[Plugin no Gihub](https://github.com/caelum/vraptor-jpa).
 
 ##VRaptor Hibernate
 
@@ -53,7 +53,7 @@ Você pode adicioná-lo em seu projeto Maven conforme o trecho abaixo, ou copiar
 </dependency>
 ~~~ 
 
-Plugin no Gihub: https://github.com/caelum/vraptor-hibernate
+[Plugin no Gihub](https://github.com/caelum/vraptor-hibernate).
 
 ##Simple mail
 
@@ -68,7 +68,7 @@ Permite envio de e-mails.
 </dependency>
 ~~~ 
 
-Plugin no Gihub: https://github.com/caelum/vraptor-simplemail
+[Plugin no Gihub](https://github.com/caelum/vraptor-simplemail).
 
 ##VRaptor Shiro
 
@@ -83,7 +83,7 @@ O VRaptor Apache Shiro Plugin provê suporte a autenticação, autorização, cr
 </dependency>
 ~~~ 
 
-Plugin no Gihub: https://github.com/dipold/vraptor-shiro
+[Plugin no Gihub](https://github.com/dipold/vraptor-shiro).
 
 ## Joda-time
 
@@ -98,7 +98,7 @@ Joda-time é uma API para facilitar o trabalho de dados temporais em Java. Para 
 </dependency>
 ~~~
 
-Plugin no Gihub: https://github.com/caelum/vraptor-time-converters
+[Plugin no Gihub](https://github.com/caelum/vraptor-time-converters).
 
 ## Nova API de datas do Java
 
@@ -113,7 +113,7 @@ Se você utiliza Java 8, você pode tirar proveito da nova API de datas do pacot
 </dependency>
 ~~~
 
-Plugin no Gihub: https://github.com/caelum/vraptor-time-converters
+[Plugin no Gihub](https://github.com/caelum/vraptor-time-converters).
 
 ##VRaptor Error-Control
 
@@ -128,7 +128,7 @@ Controle dos erros de sua aplicação em tempo real com o envio de e-mail.
 </dependency>
 ~~~ 
 
-Plugin no Gihub: https://github.com/caelum/vraptor-error-control
+[Plugin no Gihub](https://github.com/caelum/vraptor-error-control).
 
 ##VRaptor Brutauth
 
@@ -143,7 +143,7 @@ Forma fácil de verificar as permissões de acesso das ações de seu controller
 </dependency>
 ~~~ 
 
-Plugin no Gihub: https://github.com/leonardowolter/vraptor-brutauth
+[Plugin no Gihub](https://github.com/leonardowolter/vraptor-brutauth).
 
 ##VRaptor QuartzJob
 
@@ -158,7 +158,7 @@ Agendamento de tarefas com Quartz.
 </dependency>
 ~~~ 
 
-Plugin no Gihub: http://github.com/caelum/vraptor-quartzjob
+[Plugin no Gihub](http://github.com/caelum/vraptor-quartzjob).
 
 ##VRaptor Freemarker
 
@@ -173,7 +173,7 @@ Renderizar templates freemarker.
 </dependency>
 ~~~ 
 
-Plugin no Gihub: http://github.com/caelum/vraptor-freemarker
+[Plugin no Gihub](http://github.com/caelum/vraptor-freemarker).
 
 ##VRaptor Dash
 
@@ -188,7 +188,7 @@ Dashboard com varias ferramentas para seus projetos VRaptor.
 </dependency>
 ~~~ 
 
-Plugin no Gihub: http://github.com/caelum/vraptor-dash
+[Plugin no Gihub](http://github.com/caelum/vraptor-dash).
 
 ##VRaptor Authz
 
@@ -203,10 +203,8 @@ Alternativa para controle de acesso (autorização) de seus métodos do controll
 </dependency>
 ~~~ 
 
-Plugin no Gihub: https://github.com/Turini/vraptor-authz
+[Plugin no Gihub](https://github.com/Turini/vraptor-authz).
 
 ##VRaptor contrib
 
-https://github.com/caelum/vraptor-contrib
-
-Aqui você pode encontrar alguns plugins feitos por usuários do VRaptor.
+Você pode encontrar alguns plugins feitos por usuários do VRaptor no [vraptor-contrib](https://github.com/caelum/vraptor-contrib).


### PR DESCRIPTION
for some reason kramdown do not autolink it.
it was just like plain text
