### PR TITLE
Fixing a typo and a little improvement removing repeated words.

### DIFF
--- a/vraptor-site/content/pt/docs/testando-componentes-e-controllers.html
+++ b/vraptor-site/content/pt/docs/testando-componentes-e-controllers.html
@@ -106,6 +106,8 @@ public void shouldThrowValidationException() {
 		Assert.fail();
 	} catch (ValidationException e) {
 		List<Message> errors = e.getErrors();
+		Assert.assertTrue(errors.contains(new SimpleMessage("nome", "O nome deve ser preenchido")));
+		Assert.assertEquals(1, errors.size());
 	}
 }
 ~~~


### PR DESCRIPTION
Fixing a typo `quaquer` to `qualquer`.

In this text, the word `erro` is often repeated: `O MockValidator vai acumular os erros gerados, e quando o validator.onErrorUse for chamado, vai lançar um ValidationException caso haja algum erro. Assim, você pode inspecionar os erros adicionados, consultar sua lista de erros.`

So, I changed to this:

`O MockValidator vai executar a validação acumulando possíveis erros que irão gerar um ValidationException na chamada do método validator.onErrorUse. Isso permitirá que os resultados sejam inspecionados.`

What do tou think about ?
