### PR TITLE
Add module vraptor-musicjungle on pom.xml of vraptor-parent.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
 	
 	<modules>
 		<module>vraptor-core</module>
+		<module>vraptor-musicjungle</module>
 	</modules>
 	
 	<build>


### PR DESCRIPTION
Since we have unit tests in `vraptor-musicjungle`, I think we need run them from `vraptor-parent` module because changes on `vraptor-core` may affect `vraptor-musicjungle`'s tests.

What do you think ?
