### PR TITLE
Initial support for Java Parameter Names

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/JavaParameterNameProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/JavaParameterNameProvider.java
@@ -1,0 +1,56 @@
+package br.com.caelum.vraptor.http;
+
+import java.lang.reflect.AccessibleObject;
+import java.util.concurrent.Callable;
+
+import javax.enterprise.inject.Vetoed;
+
+import net.vidageek.mirror.dsl.Mirror;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import br.com.caelum.vraptor.cache.CacheStore;
+
+@Vetoed
+public class JavaParameterNameProvider
+	implements ParameterNameProvider {
+
+	private static final Logger logger = LoggerFactory.getLogger(JavaParameterNameProvider.class);
+
+	private final CacheStore<AccessibleObject, Parameter[]> cache;
+
+	public JavaParameterNameProvider(CacheStore<AccessibleObject, Parameter[]> cache) {
+		this.cache = cache;
+	}
+
+	@Override
+	public Parameter[] parametersFor(final AccessibleObject executable) {
+		return cache.fetch(executable, new Callable<Parameter[]>() {
+			@Override
+			public Parameter[] call()
+				throws Exception {
+				logger.debug("looking for parameter names {}", executable);
+
+				Object[] params = (Object[]) new Mirror().on((Object) executable).invoke().method("getParameters").withoutArgs();
+				Parameter[] out = new Parameter[params.length];
+
+				for (int i = 0; i < params.length; i++) {
+					if (isParameterPresent(params[i])) {
+						String name = (String) new Mirror().on(params[i]).invoke().method("getName").withoutArgs();
+						out[i] = new Parameter(i, name, executable);
+					} else {
+						throw new IllegalStateException("No parameters found for method " + executable
+								+ ". Make sure your code was compiled with -parameters option.");
+					}
+				}
+
+				return out;
+			}
+		});
+	}
+
+	private boolean isParameterPresent(Object param) {
+		return (Boolean) new Mirror().on(param).invoke().method("isNamePresent").withoutArgs();
+	}
+}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ParamaterNameProviderFactory.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ParamaterNameProviderFactory.java
@@ -1,0 +1,35 @@
+package br.com.caelum.vraptor.http;
+
+import java.lang.reflect.AccessibleObject;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import br.com.caelum.vraptor.cache.CacheStore;
+
+@Dependent
+public class ParamaterNameProviderFactory {
+
+	private final CacheStore<AccessibleObject, Parameter[]> cache;
+
+	protected ParamaterNameProviderFactory() {
+		this(null);
+	}
+
+	@Inject
+	public ParamaterNameProviderFactory(CacheStore<AccessibleObject, Parameter[]> cache) {
+		this.cache = cache;
+	}
+
+	@ApplicationScoped
+	@Produces
+	public ParameterNameProvider instance() {
+		return isJava8() ? new JavaParameterNameProvider(cache) : new ParanamerNameProvider();
+	}
+
+	private boolean isJava8() {
+		return System.getProperty("java.vm.specification.version").equals("1.8");
+	}
+}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ParanamerNameProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ParanamerNameProvider.java
@@ -18,7 +18,7 @@ package br.com.caelum.vraptor.http;
 
 import java.lang.reflect.AccessibleObject;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Vetoed;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ import com.thoughtworks.paranamer.Paranamer;
  *
  * @author Guilherme Silveira
  */
-@ApplicationScoped
+@Vetoed
 public class ParanamerNameProvider implements ParameterNameProvider {
 	private static final Logger logger = LoggerFactory.getLogger(ParanamerNameProvider.class);
 


### PR DESCRIPTION
Do not merge yet. This pull request is first for discuss about Java Parameters. I've tested this code in my application and works fine. And since this pull request is only a draft, I didn't write tests neither docs until now.

We have some issues for people who uses Java 8, because Paranamer can't recognize bytecode that have lambdas. Parameter wasn't designed to work with Java 8, because Java 8 already have out-of-box methods to get parametet names.

So this pull request checks if app is running under Java 8, and enable a component that uses Java Reflection to get parameter names. 

I don't like to use reflection because have less performance against normal invocation. But to avoid using reflection we need to change compiler version to Java 8. So I don't know what's the best option.

Closes #608 
