### PR TITLE
Update MethodInfo with the controller and method that really deal with the request

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultLogicResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultLogicResult.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import br.com.caelum.vraptor.Get;
-import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.controller.DefaultControllerMethod;
 import br.com.caelum.vraptor.controller.HttpMethod;
 import br.com.caelum.vraptor.core.MethodInfo;
@@ -101,10 +100,8 @@ public class DefaultLogicResult implements LogicResult {
 			public Object intercept(T proxy, Method method, Object[] args, SuperMethod superMethod) {
 				try {
 					logger.debug("Executing {}", method);
-					ControllerMethod old = methodInfo.getControllerMethod();
 					methodInfo.setControllerMethod(DefaultControllerMethod.instanceFor(type, method));
 					Object result = method.invoke(container.instanceFor(type), args);
-					methodInfo.setControllerMethod(old);
 
 					Type returnType = method.getGenericReturnType();
 					if (!(returnType == void.class)) {
@@ -134,6 +131,8 @@ public class DefaultLogicResult implements LogicResult {
 			@Override
 			public Object intercept(T proxy, Method method, Object[] args, SuperMethod superMethod) {
 				checkArgument(acceptsHttpGet(method), "Your logic method must accept HTTP GET method if you want to redirect to it");
+				
+				methodInfo.setControllerMethod(DefaultControllerMethod.instanceFor(type, method));
 				
 				try {
 					String url = router.urlFor(type, method, args);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import br.com.caelum.vraptor.controller.ControllerMethod;
-import br.com.caelum.vraptor.core.MethodInfo;
 import br.com.caelum.vraptor.http.FormatResolver;
 
 /**
@@ -40,26 +39,23 @@ public class DefaultPathResolver implements PathResolver {
 
 	private static final Logger logger = LoggerFactory.getLogger(DefaultPathResolver.class);
 	private final FormatResolver resolver;
-	private final MethodInfo methodInfo;
 	
 	/** 
 	 * @deprecated CDI eyes only
 	 */
 	protected DefaultPathResolver() {
-		this(null, null);
+		this(null);
 	}
 
 	@Inject
-	public DefaultPathResolver(FormatResolver resolver, MethodInfo methodInfo) {
+	public DefaultPathResolver(FormatResolver resolver) {
 		this.resolver = resolver;
-		this.methodInfo = methodInfo;
 	}
 	
 	@Override
 	public String pathFor(ControllerMethod method) {
 		logger.debug("Resolving path for {}", method);
 		
-		methodInfo.setControllerMethod(method);
 		String format = resolver.getAcceptFormat();
 
 		String suffix = "";

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultLogicResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultLogicResultTest.java
@@ -19,6 +19,7 @@ package br.com.caelum.vraptor.view;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -35,6 +36,8 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 
 import javax.servlet.RequestDispatcher;
+
+import net.vidageek.mirror.dsl.Mirror;
 
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -218,6 +221,26 @@ public class DefaultLogicResultTest {
 		} catch (IllegalArgumentException e) {
 			verify(response, never()).sendRedirect(any(String.class));
 		}
+	}
+	
+	@Test
+	public void shouldUpdateMethodInfoWhenForwardRequest() throws NoSuchMethodException, SecurityException {
+	    givenDispatcherWillBeReturnedWhenRequested();
+
+	    logicResult.forwardTo(MyComponent.class).annotated();
+	    
+	    ControllerMethod controllerMethod = DefaultControllerMethod.instanceFor(MyComponent.class, new Mirror().on(MyComponent.class).reflect().method("annotated").withoutArgs());
+	    assertTrue(methodInfo.getControllerMethod().equals(controllerMethod));
+	}
+	
+	@Test
+	public void shouldUpdateMethodInfoWhenRedirectRequest() throws NoSuchMethodException, SecurityException {
+	    givenDispatcherWillBeReturnedWhenRequested();
+
+	    logicResult.redirectTo(MyComponent.class).base();
+	    
+	    ControllerMethod controllerMethod = DefaultControllerMethod.instanceFor(MyComponent.class, new Mirror().on(MyComponent.class).reflect().method("base").withoutArgs());
+	    assertTrue(methodInfo.getControllerMethod().equals(controllerMethod));
 	}
 
 	@Test(expected=ValidationException.class)

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultPathResolverTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultPathResolverTest.java
@@ -19,7 +19,6 @@ package br.com.caelum.vraptor.view;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
@@ -29,7 +28,6 @@ import org.mockito.MockitoAnnotations;
 
 import br.com.caelum.vraptor.controller.BeanClass;
 import br.com.caelum.vraptor.controller.ControllerMethod;
-import br.com.caelum.vraptor.core.MethodInfo;
 import br.com.caelum.vraptor.http.FormatResolver;
 
 public class DefaultPathResolverTest {
@@ -37,7 +35,6 @@ public class DefaultPathResolverTest {
 	private @Mock ControllerMethod method;
 	private @Mock BeanClass controller;
 	private @Mock FormatResolver formatResolver;
-	private @Mock MethodInfo methodInfo;
 
 	private DefaultPathResolver resolver;
 
@@ -47,7 +44,7 @@ public class DefaultPathResolverTest {
 	public void config() throws Exception {
 		MockitoAnnotations.initMocks(this);
 
-		resolver = new DefaultPathResolver(formatResolver, methodInfo);
+		resolver = new DefaultPathResolver(formatResolver);
 		when(method.getController()).thenReturn(controller);
 		when(method.getMethod()  ).thenReturn(DogController.class.getDeclaredMethod("bark"));
 		when(controller.getType()  ).thenReturn((Class) DogController.class);
@@ -77,12 +74,6 @@ public class DefaultPathResolverTest {
 		String result = resolver.pathFor(method);
 
 		assertThat(result, is("/WEB-INF/jsp/dog/bark.jsp"));
-	}
-	
-	@Test
-	public void shouldUpdateMethodInfoWithActualControllerMethod() {
-	    resolver.pathFor(method);
-	    verify(methodInfo).setControllerMethod(method);
 	}
 
 }


### PR DESCRIPTION
This is needed because when one controller method redirect or foward to another controller or another method, the MethodInfo remains with the original called method and not with the method that was last called.

For example, if we want to create a js and css renderer based on what controller and method has rendered the page, we need to know the method that rendered the request and not the method that was first called.
