### PR TITLE
Using EL Expression tests for messages

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -92,10 +92,12 @@
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
-					<artifactId>
-						jboss-interceptors-api_1.1_spec
-					</artifactId>
+					<artifactId>jboss-interceptors-api_1.1_spec</artifactId>
 					<groupId>org.jboss.spec.javax.interceptor</groupId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.el</groupId>
+					<artifactId>el-api</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -217,6 +219,13 @@
 			<groupId>org.jboss.weld.se</groupId>
 			<artifactId>weld-se-core</artifactId>
 			<version>2.1.2.Final</version>
+			<scope>provided</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>javax.el</groupId>
+			<artifactId>javax.el-api</artifactId>
+			<version>3.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MessagesTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MessagesTest.java
@@ -5,10 +5,14 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
+
+import javax.el.ELProcessor;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -86,5 +90,27 @@ public class MessagesTest {
 		assertThat(messages.getInfo(), contains(message2));
 		assertThat(messages.getWarnings(), contains(message3));
 		assertThat(messages.getSuccess(), empty());
+	}
+
+	@Test
+	public void testElExpressionGettingMessagesByCaegory() {
+		messages.add(new SimpleMessage("client.id", "will generated", Severity.INFO));
+		messages.add(new SimpleMessage("client.name", "not null"));
+		messages.add(new SimpleMessage("client.name", "not empty"));
+
+		ELProcessor el = new ELProcessor();
+		el.defineBean("messages", messages);
+
+		String result = el.eval("messages.errors.from('client.name')").toString();
+		assertThat(result, is("not null, not empty"));
+
+		result = el.eval("messages.errors.from('client.name').join(' - ')").toString();
+		assertThat(result, is("not null - not empty"));
+
+		result = el.eval("messages.errors.from('client.id')").toString();
+		assertThat(result, isEmptyString());
+
+		result = el.eval("messages.info.from('client.id')").toString();
+		assertThat(result, is("will generated"));
 	}
 }


### PR DESCRIPTION
May be useful? I think that we can improve our tests checking if expression language can catch properly some objects we export to view.

Since `javax.el` artifact is marked as provided, I think that won't generated any dependency problem.
