### PR TITLE
Using Supplier instead of Callable to get objects as lazy

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/CacheStore.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/CacheStore.java
@@ -15,7 +15,7 @@
  */
 package br.com.caelum.vraptor.cache;
 
-import java.util.concurrent.Callable;
+import com.google.common.base.Supplier;
 
 /**
  *
@@ -51,6 +51,6 @@ public interface CacheStore<K,V> {
 	 * @param valueProvider
 	 * @return the stored or the new value for the provided key.
 	 */
-	public V fetch(K key, Callable<V> valueProvider);
+	public V fetch(K key, Supplier<V> valueProvider);
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/DefaultCacheStore.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/DefaultCacheStore.java
@@ -17,12 +17,13 @@ package br.com.caelum.vraptor.cache;
 
 import static com.google.common.base.Throwables.propagateIfPossible;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Default;
+
+import com.google.common.base.Supplier;
 
 @Default
 @Dependent
@@ -31,10 +32,10 @@ public class DefaultCacheStore<K,V> implements CacheStore<K,V> {
 	private final ConcurrentMap<K,V> cache = new ConcurrentHashMap<>();
 
 	@Override
-	public V fetch(K key, Callable<V> valueProvider) {
+	public V fetch(K key, Supplier<V> valueProvider) {
 		if (!cache.containsKey(key)){
 			try {
-				V value = valueProvider.call();
+				V value = valueProvider.get();
 				cache.put(key, value);
 				return value;
 			} catch (Exception e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/LRUCacheStore.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/LRUCacheStore.java
@@ -20,9 +20,10 @@ import static com.google.common.base.Throwables.propagateIfPossible;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 import javax.enterprise.inject.Vetoed;
+
+import com.google.common.base.Supplier;
 
 /**
  * A LRU cache based on LinkedHashMap.
@@ -47,10 +48,10 @@ public class LRUCacheStore<K, V> extends LinkedHashMap<K, V> implements CacheSto
 	}
 
 	@Override
-	public V fetch(K key, Callable<V> valueProvider) {
+	public V fetch(K key, Supplier<V> valueProvider) {
 		if (!this.containsKey(key)){
 			try {
-				V value = valueProvider.call();
+				V value = valueProvider.get();
 				put(key, value);
 				return value;
 			} catch (Exception e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultConverters.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultConverters.java
@@ -20,7 +20,6 @@ package br.com.caelum.vraptor.core;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.util.LinkedList;
-import java.util.concurrent.Callable;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -36,6 +35,7 @@ import br.com.caelum.vraptor.converter.Converter;
 import br.com.caelum.vraptor.ioc.Container;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
 
 @ApplicationScoped
@@ -81,9 +81,9 @@ public class DefaultConverters implements Converters {
 	}
 
 	private Class<? extends Converter<?>> findConverterType(final Class<?> clazz) {
-		return cache.fetch(clazz, new Callable<Class<? extends Converter<?>>>() {
+		return cache.fetch(clazz, new Supplier<Class<? extends Converter<?>>>() {
 			@Override
-			public Class<? extends Converter<?>> call() throws Exception {
+			public Class<? extends Converter<?>> get() {
 				return FluentIterable.from(classes).filter(matchConverter(clazz))
 						.first().or(NullConverter.class);
 			}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultInterceptorHandlerFactory.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultInterceptorHandlerFactory.java
@@ -15,8 +15,6 @@
  */
 package br.com.caelum.vraptor.core;
 
-import java.util.concurrent.Callable;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -29,6 +27,8 @@ import br.com.caelum.vraptor.interceptor.InterceptorAcceptsExecutor;
 import br.com.caelum.vraptor.interceptor.InterceptorExecutor;
 import br.com.caelum.vraptor.interceptor.StepInvoker;
 import br.com.caelum.vraptor.ioc.Container;
+
+import com.google.common.base.Supplier;
 
 /**
  * @author Lucas Cavalcanti
@@ -67,9 +67,9 @@ public class DefaultInterceptorHandlerFactory implements InterceptorHandlerFacto
 
 	@Override
 	public InterceptorHandler handlerFor(final Class<?> type) {
-		return cachedHandlers.fetch(type, new Callable<InterceptorHandler>() {
+		return cachedHandlers.fetch(type, new Supplier<InterceptorHandler>() {
 			@Override
-			public InterceptorHandler call() throws Exception {
+			public InterceptorHandler get() {
 				if(type.isAnnotationPresent(Intercepts.class) && !Interceptor.class.isAssignableFrom(type)){
 					return new AspectStyleInterceptorHandler(type, stepInvoker, container, customAcceptsExecutor,
 							acceptsExecutor, interceptorExecutor);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouter.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -44,6 +43,7 @@ import br.com.caelum.vraptor.http.ParameterNameProvider;
 import br.com.caelum.vraptor.proxy.Proxifier;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
 
 /**
@@ -162,9 +162,9 @@ public class DefaultRouter implements Router {
 		final Class<?> rawtype = proxifier.isProxyType(type) ? type.getSuperclass() : type;
 		final Invocation invocation = new Invocation(rawtype, method);
 
-		Route route = cache.fetch(invocation, new Callable<Route>() {
+		Route route = cache.fetch(invocation, new Supplier<Route>() {
 			@Override
-			public Route call() throws Exception {
+			public Route get() {
 				return FluentIterable.from(routes).filter(canHandle(rawtype, method))
 					.first().or(NULL);
 			}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultAcceptHeaderToFormat.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultAcceptHeaderToFormat.java
@@ -19,7 +19,6 @@ package br.com.caelum.vraptor.view;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,6 +30,7 @@ import br.com.caelum.vraptor.cache.CacheStore;
 import br.com.caelum.vraptor.cache.LRU;
 
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
 
 /**
@@ -78,9 +78,9 @@ public class DefaultAcceptHeaderToFormat implements AcceptHeaderToFormat {
 			return DEFAULT_FORMAT;
 		}
 
-		return acceptToFormatCache.fetch(acceptHeader, new Callable<String>() {
+		return acceptToFormatCache.fetch(acceptHeader, new Supplier<String>() {
 			@Override
-			public String call() throws Exception {
+			public String get() {
 				return chooseMimeType(acceptHeader);
 			}
 		});


### PR DESCRIPTION
Because `Supplier` is the right type to get objects using lazy approach. 

Since we are using Java 7 without lambdas, we can use Guava Supplier. And when we decide to use Java 8, will too easy to migrate.

Cache is a internal feature, designed to use only in our internal code. So there is no problems  to change methods signature.
