### PR TITLE
Fixing #734 that causes a StackOverflow when we use Result.redirectTo

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/AbstractResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/AbstractResult.java
@@ -15,11 +15,11 @@
  */
 package br.com.caelum.vraptor.core;
 
+import static br.com.caelum.vraptor.proxy.CDIProxies.extractRawTypeIfPossible;
 import static br.com.caelum.vraptor.view.Results.logic;
 import static br.com.caelum.vraptor.view.Results.page;
 import static br.com.caelum.vraptor.view.Results.status;
 import br.com.caelum.vraptor.Result;
-import br.com.caelum.vraptor.proxy.CDIProxies;
 import br.com.caelum.vraptor.view.Results;
 
 /**
@@ -59,19 +59,19 @@ public abstract class AbstractResult implements Result {
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T redirectTo(T controller) {
-		return (T) redirectTo(CDIProxies.extractRawTypeIfPossible(controller.getClass()));
+		return (T) redirectTo((Class<T>) extractRawTypeIfPossible(controller.getClass()));
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T forwardTo(T controller) {
-		return (T) forwardTo(CDIProxies.extractRawTypeIfPossible(controller.getClass()));
+		return (T) forwardTo((Class<T>) extractRawTypeIfPossible(controller.getClass()));
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T of(T controller) {
-		return (T) of(CDIProxies.extractRawTypeIfPossible(controller.getClass()));
+		return (T) of((Class<T>) extractRawTypeIfPossible(controller.getClass()));
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #734 pull request that causes a `StackOverflowError` when I use a `Result.redirectTo(Object)` in my application. The #734 pull request forgot to add a cast to `Class<T>` to call `Result.redirectTo(Class<T>)`. So the method call himself infinitely throwing a `StackOverflowError`.

I'll merge this pull request because can break some apps. I have tested in my application right now and everything works fine. And if any problems occurs we can fix (I think won't), we can rollback.
