### PR TITLE
Linking vraptor-brutauth to VRaptor4Version branch.

### DIFF
--- a/vraptor-site/content/en/docs/plugins.html
+++ b/vraptor-site/content/en/docs/plugins.html
@@ -144,7 +144,7 @@ Easy way to verify permission to access(authorization) a specific controller act
 </dependency>
 ~~~ 
 
-[Plugin page at Github](https://github.com/caelum/vraptor-brutauth/tree/VRaptor4Version).
+[Plugin page at Github](https://github.com/caelum/vraptor-brutauth).
 
 ##VRaptor QuartzJob
 

--- a/vraptor-site/content/pt/docs/plugins.html
+++ b/vraptor-site/content/pt/docs/plugins.html
@@ -145,7 +145,7 @@ Forma fácil de verificar as permissões de acesso das ações de seu controller
 </dependency>
 ~~~ 
 
-[Plugin no Github](https://github.com/caelum/vraptor-brutauth/tree/VRaptor4Version).
+[Plugin no Github](https://github.com/caelum/vraptor-brutauth).
 
 
 ##VRaptor QuartzJob


### PR DESCRIPTION
Since the branch master use VRaptor 3, what about link the plugin to VRaptor4Version branch ?
