### PR TITLE
Register VRaptor filter with asyncSupported=true

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptor.java
@@ -55,7 +55,7 @@ import br.com.caelum.vraptor.ioc.cdi.CDIRequestFactories;
  * @author Guilherme Silveira
  * @author Fabio Kung
  */
-@WebFilter(filterName="vraptor", urlPatterns="/*", dispatcherTypes={DispatcherType.FORWARD, DispatcherType.REQUEST})
+@WebFilter(filterName="vraptor", urlPatterns="/*", dispatcherTypes={DispatcherType.FORWARD, DispatcherType.REQUEST}, asyncSupported=true)
 public class VRaptor implements Filter {
 
 	public static final String VERSION = "4.1.0-RC4-SNAPSHOT";


### PR DESCRIPTION
The VRaptor filter should be registered with `asyncSupported=true` to not break frameworks like Atmosphere.  
