### PR TITLE
Serializee is a managed class and we should use always an injected instance

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
@@ -36,11 +36,12 @@ import com.thoughtworks.xstream.mapper.MapperWrapper;
 public class VRaptorClassMapper extends MapperWrapper {
 
 	private final Supplier<TypeNameExtractor> extractor;
-	private final Serializee serializee = new Serializee();
+	private final Supplier<Serializee> serializee;
 
-	public VRaptorClassMapper(Mapper wrapped, Supplier<TypeNameExtractor> supplier) {
+	public VRaptorClassMapper(Mapper wrapped, Supplier<TypeNameExtractor> supplier, Supplier<Serializee> serializee) {
 		super(wrapped);
 		this.extractor = supplier;
+		this.serializee = serializee;
 	}
 
 	static boolean isPrimitive(Class<?> type) {
@@ -56,19 +57,19 @@ public class VRaptorClassMapper extends MapperWrapper {
 
 	@Override
 	public boolean shouldSerializeMember(Class definedIn, String fieldName) {
-		for (Entry<String, Class<?>> include : serializee.getIncludes().entries()) {
+		for (Entry<String, Class<?>> include : getSerializee().getIncludes().entries()) {
 			if (isCompatiblePath(include, definedIn, fieldName)) {
 				return true;
 			}
 		}
-		for (Entry<String, Class<?>> exclude : serializee.getExcludes().entries()) {
+		for (Entry<String, Class<?>> exclude : getSerializee().getExcludes().entries()) {
 			if (isCompatiblePath(exclude, definedIn, fieldName)) {
 				return false;
 			}
 		}
 
 		boolean should = super.shouldSerializeMember(definedIn, fieldName);
-		if (!serializee.isRecursive())
+		if (!getSerializee().isRecursive())
 			should = should && isPrimitive(new Mirror().on(definedIn).reflect().field(fieldName).getType());
 		return should;
 	}
@@ -91,6 +92,6 @@ public class VRaptorClassMapper extends MapperWrapper {
 	}
 	
 	public Serializee getSerializee() {
-		return serializee;
+		return serializee.get();
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorXStream.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorXStream.java
@@ -18,6 +18,7 @@ package br.com.caelum.vraptor.serialization.xstream;
 import javax.enterprise.inject.Vetoed;
 
 import br.com.caelum.vraptor.interceptor.TypeNameExtractor;
+import br.com.caelum.vraptor.serialization.Serializee;
 
 import com.google.common.base.Supplier;
 import com.thoughtworks.xstream.XStream;
@@ -28,18 +29,21 @@ import com.thoughtworks.xstream.mapper.MapperWrapper;
 @Vetoed
 public  class VRaptorXStream extends XStream {
 	private final TypeNameExtractor extractor;
+	private final Serializee serializee;
 	private VRaptorClassMapper vraptorMapper;
 
 	{setMode(NO_REFERENCES);}
 
-	public VRaptorXStream(TypeNameExtractor extractor) {
+	public VRaptorXStream(TypeNameExtractor extractor, Serializee serializee) {
 		super(new PureJavaReflectionProvider());
 		this.extractor = extractor;
+		this.serializee = serializee;
 	}
 	
-	public VRaptorXStream(TypeNameExtractor extractor, HierarchicalStreamDriver hierarchicalStreamDriver) {
+	public VRaptorXStream(TypeNameExtractor extractor, HierarchicalStreamDriver hierarchicalStreamDriver, Serializee serializee) {
 		super(new PureJavaReflectionProvider(),hierarchicalStreamDriver);
 		this.extractor = extractor;
+		this.serializee = serializee;
 	}
 
 	@Override
@@ -52,6 +56,12 @@ public  class VRaptorXStream extends XStream {
 			@Override
 			public TypeNameExtractor get() {
 				return extractor;
+			}
+		}, 
+		new Supplier<Serializee>() {
+			@Override
+			public Serializee get() {
+				return serializee;
 			}
 		});
 		return vraptorMapper;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamBuilderImpl.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamBuilderImpl.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 
 import br.com.caelum.vraptor.interceptor.DefaultTypeNameExtractor;
 import br.com.caelum.vraptor.interceptor.TypeNameExtractor;
+import br.com.caelum.vraptor.serialization.Serializee;
 import br.com.caelum.vraptor.util.test.MockInstanceImpl;
 
 import com.thoughtworks.xstream.XStream;
@@ -38,6 +39,7 @@ public class XStreamBuilderImpl implements XStreamBuilder {
 
 	private final XStreamConverters converters;
 	private final TypeNameExtractor extractor;
+	private final Serializee serializee;
 	private boolean indented = false;
 	private boolean recursive = false;
 	
@@ -45,26 +47,27 @@ public class XStreamBuilderImpl implements XStreamBuilder {
 	 * @deprecated CDI eyes only
 	 */
 	protected XStreamBuilderImpl() {
-		this(null, null);
+		this(null, null, null);
 	}
 
 	@Inject
-	public XStreamBuilderImpl(XStreamConverters converters, TypeNameExtractor extractor) {
+	public XStreamBuilderImpl(XStreamConverters converters, TypeNameExtractor extractor, Serializee serializee) {
 		this.converters = converters;
 		this.extractor = extractor;
+		this.serializee = serializee;
 	}
 
 	public static XStreamBuilder cleanInstance(Converter...converters) {
 		Instance<Converter> convertersInst = new MockInstanceImpl<>(converters);
 		Instance<SingleValueConverter> singleValueConverters = new MockInstanceImpl<>();
 		XStreamConverters xStreamConverters = new XStreamConverters(convertersInst, singleValueConverters);
-		return new XStreamBuilderImpl(xStreamConverters, new DefaultTypeNameExtractor());
+		return new XStreamBuilderImpl(xStreamConverters, new DefaultTypeNameExtractor(), new Serializee());
 	}
 	
 	@Override
 	public XStream xmlInstance() {
-		VRaptorXStream xstream = new VRaptorXStream(extractor);
-		xstream.getVRaptorMapper().getSerializee().setRecursive(recursive);
+		VRaptorXStream xstream = new VRaptorXStream(extractor, serializee);
+		serializee.setRecursive(recursive);
 		return configure(xstream);
 	}
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/xstream/XStreamSerializerTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/xstream/XStreamSerializerTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 
 import br.com.caelum.vraptor.environment.Environment;
 import br.com.caelum.vraptor.interceptor.DefaultTypeNameExtractor;
+import br.com.caelum.vraptor.serialization.Serializee;
 import br.com.caelum.vraptor.util.test.MockInstanceImpl;
 
 import com.thoughtworks.xstream.XStream;
@@ -61,6 +62,6 @@ public class XStreamSerializerTest extends XStreamXMLSerializationTest {
 		Instance<Converter> convertersInst = new MockInstanceImpl<>(converters);
 		Instance<SingleValueConverter> singleValueConverters = new MockInstanceImpl<>();
 		XStreamConverters xStreamConverters = new XStreamConverters(convertersInst, singleValueConverters);
-		serialization = new XStreamXMLSerialization(response, new XStreamBuilderImpl(xStreamConverters, extractor), environment);
+		serialization = new XStreamXMLSerialization(response, new XStreamBuilderImpl(xStreamConverters, extractor, new Serializee()), environment);
 	}
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultStatusTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultStatusTest.java
@@ -185,7 +185,7 @@ public class DefaultStatusTest {
 		i18ned.setBundle(new SingletonResourceBundle("message", "Something else"));
 
 		XStreamBuilder xstreamBuilder = cleanInstance(new MessageConverter());
-		MockSerializationResult result = new MockSerializationResult(null, xstreamBuilder, null);
+		MockSerializationResult result = new MockSerializationResult(null, xstreamBuilder, null, null);
 		DefaultStatus status = new DefaultStatus(response, result, config, new JavassistProxifier(), router);
 
 		status.badRequest(Arrays.asList(normal, i18ned));


### PR DESCRIPTION
This change breaks compatibility because change constructor signature. Of course only for users who extends serialization internal classes. No public API was changed.

But this change is really necessary because we are not using managed `Serializee` for all classes. There are some places that uses a non managed instance that isn't the same instance in the places that uses managed instance.
