### PR TITLE
Organizing Maven dependencies

### DIFF
--- a/vraptor-core/pom.xml
+++ b/vraptor-core/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>com.thoughtworks.paranamer</groupId>
 			<artifactId>paranamer</artifactId>
-			<version>2.6</version>
+			<version>2.7</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.mockito</groupId>


### PR DESCRIPTION
With comments to help users to check if some dependency can be removed in their applications.

Questions:

1) Why `javax.inject:javax.inject` is provided but `javax.annotation:javax.annotation-api` isn't? Both are provided by appserver but no by servlet containers. The same for `javax.interceptor:javax.interceptor-api` and `javax.ejb:javax.ejb-api`. The default dependencies should focused in appserver or servlet containers?

2) Why `org.hibernate:hibernate-validator-cdi` is provided? May be this artifact should only test scoped, because we need to use in tests. Or if our focus is on servlet containers should compile.
