### PR TITLE
removing result.used from forwardTo

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultResult.java
@@ -18,7 +18,6 @@
 package br.com.caelum.vraptor.core;
 
 
-import static br.com.caelum.vraptor.view.Results.logic;
 import static java.util.Collections.unmodifiableMap;
 
 import java.util.HashMap;
@@ -81,12 +80,6 @@ public class DefaultResult extends AbstractResult {
 	    
 		responseCommitted = true;
 		return container.instanceFor(view);
-	}
-	
-	@Override
-	public <T> T forwardTo(Class<T> controller) {
-		messages.assertAbsenceOfErrors();
-		return container.instanceFor(logic()).forwardTo(controller);
 	}
 	
 	@Override

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultLogicResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultLogicResult.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import br.com.caelum.vraptor.Get;
-import br.com.caelum.vraptor.Result;
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.controller.DefaultControllerMethod;
 import br.com.caelum.vraptor.controller.HttpMethod;
@@ -68,20 +67,18 @@ public class DefaultLogicResult implements LogicResult {
 	private final TypeNameExtractor extractor;
 	private final FlashScope flash;
 	private final MethodInfo methodInfo;
-	private final Result result;
 
 	/** 
 	 * @deprecated CDI eyes only
 	 */
 	protected DefaultLogicResult() {
-		this(null, null, null, null, null, null, null, null, null, null);
+		this(null, null, null, null, null, null, null, null, null);
 	}
 
 	@Inject
 	public DefaultLogicResult(Proxifier proxifier, Router router, MutableRequest request, HttpServletResponse response,
-			Container container, PathResolver resolver, TypeNameExtractor extractor, FlashScope flash, MethodInfo methodInfo, Result result) {
+			Container container, PathResolver resolver, TypeNameExtractor extractor, FlashScope flash, MethodInfo methodInfo) {
 		this.proxifier = proxifier;
-		this.result = result;
 		this.response = unproxifyIfPossible(response);
 		this.request = unproxifyIfPossible(request);
 		this.router = router;
@@ -115,7 +112,7 @@ public class DefaultLogicResult implements LogicResult {
 						request.setAttribute(extractor.nameFor(returnType), methodResult);
 					}
 					
-					if (response.isCommitted() || result.used()) {
+					if (response.isCommitted()) {
 						logger.debug("Response already commited, not forwarding.");
 						return null;
 					}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultLogicResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultLogicResultTest.java
@@ -77,7 +77,6 @@ public class DefaultLogicResultTest {
 	private @Mock TypeNameExtractor extractor;
 	private @Mock RequestDispatcher dispatcher;
 	private @Mock FlashScope flash;
-	private @Mock Result result;
 
 	private Proxifier proxifier;
 
@@ -121,7 +120,7 @@ public class DefaultLogicResultTest {
 		proxifier = new JavassistProxifier();
 		methodInfo = new MethodInfo(new ParanamerNameProvider());
 		this.logicResult = new DefaultLogicResult(proxifier, router, request, response, container,
-				resolver, extractor, flash, methodInfo, result);
+				resolver, extractor, flash, methodInfo);
 	}
 
 	@Test


### PR DESCRIPTION
It fix #906 but reopen #778. I couldn't find better solution. I'm already sending 
the PR because  `validator.onErrorForwardTo` has higher priority than #778 
(but I'd love to get a better suggestion than this one... to finally fix both issues)
