### PR TITLE
adding view path prefix support

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import br.com.caelum.vraptor.controller.ControllerMethod;
 import br.com.caelum.vraptor.http.FormatResolver;
+import br.com.caelum.vraptor.view.annotation.ViewPathPrefix;
 
 /**
  * The default vraptor3 path resolver uses the type and method name as
@@ -64,7 +65,14 @@ public class DefaultPathResolver implements PathResolver {
 		
 		String name = method.getController().getType().getSimpleName();
 		String folderName = extractControllerFromName(name);
-		String path = getPrefix() + folderName + "/" + method.getMethod().getName() + suffix + "." + getExtension();
+		
+		String folderPrefix = "";
+		if(method.getController().getType().isAnnotationPresent(ViewPathPrefix.class)) {
+			ViewPathPrefix prefixAnnotation = method.getController().getType().getAnnotation(ViewPathPrefix.class);
+			folderPrefix = prefixAnnotation.value() + "/";
+		}
+		
+		String path = getPrefix() + folderPrefix + folderName + "/" + method.getMethod().getName() + suffix + "." + getExtension();
 
 		logger.debug("Returning path {} for {}", path, method);
 		return path;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/annotation/ViewPathPrefix.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/annotation/ViewPathPrefix.java
@@ -1,0 +1,12 @@
+package br.com.caelum.vraptor.view.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ViewPathPrefix {
+	String value();
+}


### PR DESCRIPTION
This is a new Annotation to use in Controllers that adds support to change the default JSP location, adding a folder prefix. It's quite useful when we have different Controllers with the same semantic context and want their JSPs to have the same root folder