### PR TITLE
Script to automatically deploy the site

### DIFF
--- a/update-site.sh
+++ b/update-site.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd vraptor-site
+bundle install
+rm -rf output deploy
+bundle exec nanoc
+grunt
+git checkout gh-pages
+cd ..
+cp -R vraptor-site/deploy/* .
+git commit -am 'automatically updating vraptor site'
+git checkout master

--- a/update-site.sh
+++ b/update-site.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e # halt on error
+
 rvm use --create 2.0.0@vraptor-site
 cd vraptor-site
 bundle install
@@ -10,5 +12,3 @@ cd ..
 git checkout gh-pages
 cp -R vraptor-site/deploy/* .
 git commit -am 'automatically updating vraptor site'
-git pull --rebase
-git checkout master

--- a/update-site.sh
+++ b/update-site.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+rvm use --create 2.0.0@vraptor-site
 cd vraptor-site
 bundle install
 rm -rf output deploy

--- a/update-site.sh
+++ b/update-site.sh
@@ -6,8 +6,9 @@ bundle install
 rm -rf output deploy
 bundle exec nanoc
 grunt
-git checkout gh-pages
 cd ..
+git checkout gh-pages
 cp -R vraptor-site/deploy/* .
 git commit -am 'automatically updating vraptor site'
+git pull --rebase
 git checkout master

--- a/update-site.sh
+++ b/update-site.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "$HOME/.rvm/scripts/rvm"
+
 set -e # halt on error
 
 rvm use --create 2.0.0@vraptor-site

--- a/update-site.sh
+++ b/update-site.sh
@@ -7,6 +7,7 @@ set -e # halt on error
 rvm use --create 2.0.0@vraptor-site
 cd vraptor-site
 bundle install
+npm install
 rm -rf output deploy
 bundle exec nanoc
 grunt


### PR DESCRIPTION
This script is intended to be run by a CI server (we already have one configured internally at Caelum). It builds the site from scratch and creates a commit in the `gh-pages` branch. The CI server then pushes it if the build succeeds.

This closes #923.