### PR TITLE
[proposal] extension to allow eager initialize app scoped beans

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/EagerInitialized.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/EagerInitialized.java
@@ -1,0 +1,20 @@
+package br.com.caelum.vraptor.ioc.cdi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Means that the application scoped bean should be initialized early. 
+ * @see br.com.caelum.vraptor.ioc.cdi.EagerApplicationScopedExtension
+ * 
+ * @author Rodrigo Turini
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface EagerInitialized {
+}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/extension/EagerApplicationScopedExtension.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/extension/EagerApplicationScopedExtension.java
@@ -1,0 +1,38 @@
+package br.com.caelum.vraptor.ioc.cdi.extension;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterDeploymentValidation;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.util.AnnotationLiteral;
+
+import br.com.caelum.vraptor.ioc.cdi.EagerInitialized;
+
+/**
+ * When enabled, it allows users to use {@link EagerInitialized} annotation 
+ * to get your application scoped beans initialized just after CDI deployment.
+ *
+ * @author Rodrigo Turini
+ */
+public class EagerApplicationScopedExtension implements Extension {
+	
+	@SuppressWarnings("serial")
+	public void initialize(@Observes AfterDeploymentValidation event, BeanManager beanManager) {
+		
+		Set<Bean<?>> beans = beanManager.getBeans(Object.class, 
+				new AnnotationLiteral<EagerInitialized>() {});
+		
+		for (Bean<?> bean : beans) {
+			Class<?> beanClass = bean.getBeanClass();
+			if(beanClass.isAnnotationPresent(ApplicationScoped.class)){
+				CreationalContext<?> ctx = beanManager.createCreationalContext(bean);
+				beanManager.getReference(bean, beanClass, ctx).toString();
+			}
+		}
+	}
+}


### PR DESCRIPTION
please note tha this is just a draft... if users and devs like it, I can write some docs and a
few tests (hella don't know how!). This feature was asked a few times at vraptor's user list.

With this PR, VRaptor users may add `@EagerInitialized` annotation at the application 
scoped beans that should be initialized on startup, instead of the first request. In example:

```
@ApplicationScoped @EagerInitialized
public class DummyAppScoped {

	@PostConstruct public void init() {
		System.out.println("DummyAppScoped initialized");
	}
}
```

For now the extension is disabled by default, to use it you need to manually register the
`EagerApplicationScopedExtension` on `services/javax.enterprise.inject.spi.Extension`.
If most of you agree, it can be enabled by default (I don't like it). So... what do you think?
