### PR TITLE
updating docs about javax.inject

### DIFF
--- a/vraptor-blank-project/pom.xml
+++ b/vraptor-blank-project/pom.xml
@@ -46,14 +46,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.inject</groupId>
-			<artifactId>javax.inject</artifactId>
-			<version>1</version>
-			<!-- uncomment this line on app servers -->
-			<!-- <scope>provided</scope> -->
-		</dependency>
-
-		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>jstl</artifactId>
 			<version>1.2</version>

--- a/vraptor-site/content/en/docs/dependencies-and-prerequisites.html
+++ b/vraptor-site/content/en/docs/dependencies-and-prerequisites.html
@@ -98,22 +98,9 @@ available in a `zip` file in our <a href="/en/download">downloads page</a>.
 
 ### CDI
 
-This is the most important dependency of VRaptor 4. If you use an Application Server,
-this dependency is already included, so you should declare CDI dependency with scope 
-`provided` in your `pom.xml`:
+This is the most important dependency of VRaptor 4. If you're using an Application Server, that already includes this dependency, you don't need to declare it again in your `pom.xml`.
 
-~~~
-#!xml
-<dependency>
-	<groupId>javax.inject</groupId>
-	<artifactId>javax.inject</artifactId>
-	<version>1</version>
-	<scope>provided</scope>
-</dependency>
-~~~
-
-If you are using a Servlet Container (such as Tomcat or Jetty) you need to remove line `<scope>provided</scope>` from `javax.inject` dependency and add
-the reference implementation of CDI: Weld.
+If you are using a Servlet Container (such as Tomcat or Jetty), you need to add the reference implementation of CDI: Weld.
 
 ~~~
 #!xml

--- a/vraptor-site/content/pt/docs/dependencias-e-pre-requisitos.html
+++ b/vraptor-site/content/pt/docs/dependencias-e-pre-requisitos.html
@@ -82,19 +82,9 @@ Se você não quiser usar o Maven, basta criar um projeto em branco na sua IDE p
 
 ### CDI
 
-Esta é a dependência mais importante do VRaptor 4. Se você usa um Application Server, ele já possui esta dependência, portanto você pode declarar no seu `pom.xml` como `provided` conforme exemplo:
+Esta é a dependência mais importante do VRaptor 4. Se você usa um servidor de aplicação, que já possui essa dependência, você não precisará declará-la novamente em seu `pom.xml`. 
 
-~~~
-#!xml
-<dependency>
-	<groupId>javax.inject</groupId>
-	<artifactId>javax.inject</artifactId>
-	<version>1</version>
-	<scope>provided</scope>
-</dependency>
-~~~
-
-E se você utiliza um Servlet Container (como o Tomcat ou Jetty) você precisa remover a linha `<scope>provided</scope>` da dependência `javax.inject` e adicionar a implementação de referência do CDI: o Weld.
+Caso você utilize um Servlet Container (como o Tomcat ou Jetty), você precisará adicionar a implementação de referência do CDI: o Weld.
 
 ~~~
 #!xml


### PR DESCRIPTION
* updating docs removing javax.inject dependency
* removing it from blank project's pom

that because VRaptor core already declare `javax.inject` as `provided` and `weld` 
impl already provide it for servlet containers... so, we can keep it simple for users.