### PR TITLE
standardizing the inheritance of our internal exceptions

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptorException.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/VRaptorException.java
@@ -28,6 +28,9 @@ import javax.enterprise.inject.Vetoed;
 public class VRaptorException extends RuntimeException {
 	private static final long serialVersionUID = -8040463849613736889L;
 
+	public VRaptorException() {
+	}
+	
 	public VRaptorException(Throwable e) {
 		super(e);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/CacheException.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/CacheException.java
@@ -17,8 +17,10 @@ package br.com.caelum.vraptor.cache;
 
 import javax.enterprise.inject.Vetoed;
 
+import br.com.caelum.vraptor.VRaptorException;
+
 @Vetoed
-public class CacheException extends RuntimeException {
+public class CacheException extends VRaptorException {
 
 	private static final long serialVersionUID = 1L;
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/DefaultValidationException.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/DefaultValidationException.java
@@ -18,6 +18,8 @@ package br.com.caelum.vraptor.validator;
 
 import javax.enterprise.inject.Vetoed;
 
+import br.com.caelum.vraptor.VRaptorException;
+
 /**
  * Default implementation of a {@link ValidationException}. Users can use this class 
  * if they don't want to implement their own business exceptions.
@@ -27,7 +29,7 @@ import javax.enterprise.inject.Vetoed;
  */
 @br.com.caelum.vraptor.validator.annotation.ValidationException
 @Vetoed
-public class DefaultValidationException extends RuntimeException {
+public class DefaultValidationException extends VRaptorException {
 
 	private static final long serialVersionUID = 1L;
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/ValidationException.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/ValidationException.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import javax.ejb.ApplicationException;
 
+import br.com.caelum.vraptor.VRaptorException;
+
 /**
  * If some validation error occur, its encapsulated within an instance of
  * ValidationException, which is then throw and parsed.
@@ -29,7 +31,7 @@ import javax.ejb.ApplicationException;
  */
 //just for the javaee container understands this as a Business Exception
 @ApplicationException
-public class ValidationException extends RuntimeException {
+public class ValidationException extends VRaptorException {
 
 	/**
 	 * Serialized id.


### PR DESCRIPTION
All of our exceptions inherit from `VRaptorException`, except for the 3 below.
I'm changing them to inherit it too, to keep the symmetry. What do you think?