### PR TITLE
Adding docs about MockSerializationResult.

### DIFF
--- a/vraptor-site/content/en/docs/testing-components-and-controllers.html
+++ b/vraptor-site/content/en/docs/testing-components-and-controllers.html
@@ -94,6 +94,42 @@ public void shouldHaveSuccessMessage() {
 
 Note that any call of the type `result.use(...)` will be ignored.
 
+##MockSerializationResult
+
+Very similar to `MockResult` with a difference that we can get the serialized content of `Result`.
+
+In your `PersonControllerTest` class the `result` should have the type `MockSerializationResult`, like this:
+
+~~~
+#!java
+private MockSerializationResult result;
+~~~
+
+Consider the following `PersonController`'s method:
+
+~~~
+#!java
+@Post("/person/serialize")
+public void serialize(Person person) {
+	result.use(Results.json()).from(person).serialize();
+}
+~~~
+
+In your test you can do something like:
+
+~~~
+#!java
+@Test
+public void shouldSerializePerson() {
+	Person person = new Person();
+	person.setName("Renan Montenegro");
+	
+	controller.serialize(person);
+	
+	Assert.assertEquals("{\"person\": {\"name\": \"Renan Montenegro\"}}", result.serializedResult());
+}
+~~~
+
 ##MockValidator
 
 The `MockValidator` will execute the validation accumulating possible errors. To retrieve them you can use the method `getErrors()` as you can see in the example:

--- a/vraptor-site/content/en/docs/testing-components-and-controllers.html
+++ b/vraptor-site/content/en/docs/testing-components-and-controllers.html
@@ -96,7 +96,7 @@ Note that any call of the type `result.use(...)` will be ignored.
 
 ##MockSerializationResult
 
-Very similar to `MockResult` with a difference that we can get the serialized content of `Result`.
+Very similar to `MockResult` with a difference that we can get the serialized content from `Result`.
 
 In your `PersonControllerTest` class the `result` should have the type `MockSerializationResult`, like this:
 

--- a/vraptor-site/content/en/docs/testing-components-and-controllers.html
+++ b/vraptor-site/content/en/docs/testing-components-and-controllers.html
@@ -96,7 +96,7 @@ Note that any call of the type `result.use(...)` will be ignored.
 
 ##MockSerializationResult
 
-Very similar to `MockResult` with a difference that we can get the serialized content from `Result`.
+In a similar way, you can use the `MockSerializationResult` anytime you want to inspect the serialized content in `Result`.
 
 In your `PersonControllerTest` class the `result` should have the type `MockSerializationResult`, like this:
 

--- a/vraptor-site/content/pt/docs/testando-componentes-e-controllers.html
+++ b/vraptor-site/content/pt/docs/testando-componentes-e-controllers.html
@@ -95,7 +95,7 @@ Note que qualquer chamada do tipo `result.use(...)` será ignorada.
 
 ##MockSerializationResult
 
-Muito semelhante ao `MockResult` com a diferença que podemos obter o conteúdo serializado no `Result`.
+De forma bastante semelhante, você pode utilizar o `MockSerializationResult` sempre que quiser inspecionar o conteúdo serializado no `Result`.
 
 Na sua classe `PessoaControllerTest` o `result` deve ser do tipo `MockSerializationResult`, como a seguir:
 

--- a/vraptor-site/content/pt/docs/testando-componentes-e-controllers.html
+++ b/vraptor-site/content/pt/docs/testando-componentes-e-controllers.html
@@ -65,7 +65,7 @@ Considere o seguinte método da classe `PessoaController`:
 ~~~
 #!java
 @Post("/pessoa/adiciona")
-public void add(Pessoa pessoa) {
+public void adiciona(Pessoa pessoa) {
 	validator.addIf(pessoa.getNome() == null, new SimpleMessage("nome", "O nome deve ser preenchido"));
 	validator.onErrorRedirectTo(IndexController.class).index();
 
@@ -80,7 +80,7 @@ Para testá-lo você pode em sua classe `PessoaControllerTest` fazer algo como:
 ~~~
 #!java
 @Test
-public void shouldHaveSuccessMessage() {
+public void deveConterMensagemDeSucesso() {
 	Pessoa pessoa = new Pessoa();
 	pessoa.setNome("Renan Montenegro");
 	
@@ -93,6 +93,42 @@ public void shouldHaveSuccessMessage() {
 
 Note que qualquer chamada do tipo `result.use(...)` será ignorada.
 
+##MockSerializationResult
+
+Muito semelhante ao `MockResult` com a diferença que podemos obter o conteúdo serializado no `Result`.
+
+Na sua classe `PessoaControllerTest` o `result` deve ser do tipo `MockSerializationResult`, como a seguir:
+
+~~~
+#!java
+private MockSerializationResult result;
+~~~
+
+Considere o seguinte método da classe `PessoaController`:
+
+~~~
+#!java
+@Post("/pessoa/serializa")
+public void serializa(Pessoa pessoa) {
+	result.use(Results.json()).from(pessoa).serialize();
+}
+~~~
+
+No seu teste você pode fazer algo como:
+
+~~~
+#!java
+@Test
+public void deveriaSerializarPessoa() {
+	Pessoa pessoa = new Pessoa();
+	pessoa.setNome("Renan Montenegro");
+	
+	controller.serializa(pessoa);
+	
+	Assert.assertEquals("{\"pessoa\": {\"nome\": \"Renan Montenegro\"}}", result.serializedResult());
+}
+~~~
+
 ##MockValidator
 
 O `MockValidator` vai executar a validação acumulando possíveis erros. Para recuperá-los você pode usar o método `getErrors()` como você pode ver no exemplo:
@@ -100,7 +136,7 @@ O `MockValidator` vai executar a validação acumulando possíveis erros. Para r
 ~~~
 #!java
 @Test
-public void shouldThrowValidationException() {
+public void deveLancarValidationException() {
 	try {
 		controller.add(new Pessoa());
 		Assert.fail();
@@ -117,7 +153,7 @@ A chamada do método `validator.onErrorUse`, no caso de problema de validação,
 ~~~
 #!java
 @Test(expected = ValidationException.class)
-public void shouldThrowValidationException() {
+public void deveLancarValidationException() {
 	controller.add(new Pessoa());
 }
 ~~~


### PR DESCRIPTION
In the last days, some people asked on Google Groups about how to test a Controller method that just serialize an object.

So, I wrote this little doc about `MockSerializationResult`.