### PR TITLE
relaxing visibility of Serializee getActualType

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/Serializee.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/Serializee.java
@@ -168,7 +168,7 @@ public class Serializee {
 		return field;
 	}
 
-	private static Class<?> getActualType(Type genericType) {
+	protected static Class<?> getActualType(Type genericType) {
 		if (genericType instanceof ParameterizedType) {
 			ParameterizedType type = (ParameterizedType) genericType;
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/Serializee.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/Serializee.java
@@ -147,7 +147,7 @@ public class Serializee {
 			for (int i = 0; i < path.length; i++) {
 			    Field field = reflectField(path[i], type);
 			    if (field == null) break;
-			    if (i < path.length - 1) type = getActualType(field.getGenericType());
+			    if (i < path.length - 1) type = getActualType(field);
 			}
 		} catch (NullPointerException e) {
 			throw new IllegalArgumentException("Field path '" + name + "' doesn't exists in " + type, e);
@@ -168,7 +168,10 @@ public class Serializee {
 		return field;
 	}
 
-	protected static Class<?> getActualType(Type genericType) {
+	protected static Class<?> getActualType(Field field) {
+		
+		Type genericType = field.getGenericType();
+	
 		if (genericType instanceof ParameterizedType) {
 			ParameterizedType type = (ParameterizedType) genericType;
 


### PR DESCRIPTION
It'll allow users to easily override this behavior, just like in the use case of #933.