### PR TITLE
loading properties in bean construction

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
@@ -72,7 +72,7 @@ public class DefaultEnvironment implements Environment {
 	}
 	
 	@PostConstruct
-	public void setup() {
+	protected void setup() {
 		loadProperties();
 	}
 	

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
@@ -68,26 +68,21 @@ public class DefaultEnvironment implements Environment {
 	@Inject
 	public DefaultEnvironment(ServletContext context) {
 		this.context = context;
+		loadProperties();
 	}
 
 	public DefaultEnvironment(EnvironmentType environmentType) {
 		this((ServletContext) null);
 		this.environmentType = environmentType;
 	}
-
-	private Properties getProperties() {
-		if (properties == null) {
-			properties = new Properties();
-
-			loadAndPut(BASE_ENVIRONMENT_FILE);
-			loadAndPut(getEnvironmentType().getName());
-
-			LOG.debug("Environment is up with properties {}", properties);
-		}
-
-		return properties;
+	
+	private void loadProperties() {
+		properties = new Properties();
+		loadAndPut(BASE_ENVIRONMENT_FILE);
+		loadAndPut(getEnvironmentType().getName());
+		LOG.debug("Environment is up with properties {}", properties);
 	}
-
+	
 	private EnvironmentType getEnvironmentType() {
 		if (environmentType == null) {
 			environmentType = new EnvironmentType(findEnvironmentName(context));
@@ -165,7 +160,7 @@ public class DefaultEnvironment implements Environment {
 
 	@Override
 	public boolean has(String key) {
-		return getProperties().containsKey(key);
+		return properties.containsKey(key);
 	}
 
 	@Override
@@ -178,7 +173,7 @@ public class DefaultEnvironment implements Environment {
 		if (!isNullOrEmpty(systemProperty)) {
 			return systemProperty;
 		} else {
-			return getProperties().getProperty(key);
+			return properties.getProperty(key);
 		}
 	}
 
@@ -192,12 +187,12 @@ public class DefaultEnvironment implements Environment {
 
 	@Override
 	public void set(String key, String value) {
-		getProperties().setProperty(key, value);
+		properties.setProperty(key, value);
 	}
 
 	@Override
 	public Iterable<String> getKeys() {
-		return getProperties().stringPropertyNames();
+		return properties.stringPropertyNames();
 	}
 
 	@Override

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
@@ -28,6 +28,7 @@ import java.security.PrivilegedAction;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -68,12 +69,17 @@ public class DefaultEnvironment implements Environment {
 	@Inject
 	public DefaultEnvironment(ServletContext context) {
 		this.context = context;
+	}
+	
+	@PostConstruct
+	public void setup() {
 		loadProperties();
 	}
-
+	
 	public DefaultEnvironment(EnvironmentType environmentType) {
 		this((ServletContext) null);
 		this.environmentType = environmentType;
+		loadProperties();
 	}
 	
 	private void loadProperties() {

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/environment/DefaultEnvironmentTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/environment/DefaultEnvironmentTest.java
@@ -148,7 +148,6 @@ public class DefaultEnvironmentTest {
 	
 	private DefaultEnvironment buildEnvironment(EnvironmentType environmentType) {
 		DefaultEnvironment defaultEnvironment = new DefaultEnvironment(environmentType);
-		defaultEnvironment.setup();
 		
 		return defaultEnvironment;
 	}


### PR DESCRIPTION
Fixes #972

This avoid concurrent access that could lead to errors in multithread environments.

@Turini @csokol I believe that we don't need to use the `@PostContruct` because we can do it in `DefaultEnvironment`'s constructor. What do you think about it?
