### PR TITLE
adding no-arg default constructor on InvalidInputHandler

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/controller/DefaultInvalidInputHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/controller/DefaultInvalidInputHandler.java
@@ -17,6 +17,13 @@ import br.com.caelum.vraptor.view.Results;
 public class DefaultInvalidInputHandler implements InvalidInputHandler {
 
 	private final Result result;
+	
+	/**
+	 * @deprecated CDI eyes only
+	 */
+	protected DefaultInvalidInputHandler() {
+		this(null);
+	}
 
 	@Inject
 	public DefaultInvalidInputHandler(Result result) {


### PR DESCRIPTION
I'm not sure how it was working until now, since it's a normal scoped proxyable bean. 