### PR TITLE
Defaultrefererfix

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -93,11 +93,11 @@ public class DefaultRefererResult implements RefererResult {
 		}
 	}
 
-	private String getReferer() {
+	protected String getReferer() {
 		String referer = request.getHeader("Referer");
 		checkState(referer != null, "The Referer header was not specified");
 
-		String refererPath= null;
+		String refererPath = null;
 		try {
 			refererPath = new URL(referer).getPath();
 		} catch(MalformedURLException e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -21,8 +21,6 @@ import static br.com.caelum.vraptor.view.Results.logic;
 import static br.com.caelum.vraptor.view.Results.page;
 import static com.google.common.base.Preconditions.checkState;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 
 import javax.enterprise.context.RequestScoped;
@@ -94,19 +92,11 @@ public class DefaultRefererResult implements RefererResult {
 	}
 
 	private String getReferer() {
-	    String referer = request.getHeader("Referer");
-	    checkState(referer != null, "The Referer header was not specified");
-	    
-	    String refererPath = referer;
-		try {
-		    refererPath = new URL(referer).getPath();
-		} catch(MalformedURLException e) {
-		    //Maybe a relative path?
-		    refererPath = referer;
-		}
+		String referer = request.getHeader("Referer");
+		checkState(referer != null, "The Referer header was not specified");
 
 		String path = request.getContextPath();
-		return refererPath.substring(refererPath.indexOf(path) + path.length());
+		return referer.substring(referer.indexOf(path) + path.length());
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -21,6 +21,8 @@ import static br.com.caelum.vraptor.view.Results.logic;
 import static br.com.caelum.vraptor.view.Results.page;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 
 import javax.enterprise.context.RequestScoped;
@@ -95,8 +97,15 @@ public class DefaultRefererResult implements RefererResult {
 		String referer = request.getHeader("Referer");
 		checkState(referer != null, "The Referer header was not specified");
 
-		String path = request.getContextPath();
-		return referer.substring(referer.indexOf(path) + path.length());
+		String refererPath= null;
+		try {
+			refererPath = new URL(referer).getPath();
+		} catch(MalformedURLException e) {
+			//Maybe a relative path?
+			refererPath = referer;
+		}
+		String ctxPath = request.getContextPath();
+		return refererPath.substring(refererPath.indexOf(ctxPath) + ctxPath.length());
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -105,7 +105,10 @@ public class DefaultRefererResult implements RefererResult {
 			refererPath = referer;
 		}
 		String ctxPath = request.getContextPath();
-		return refererPath.substring(refererPath.indexOf(ctxPath) + ctxPath.length());
+		
+		//if the context path is not in the beggining we should return the entire path
+		//this is useful for proxied app servers which hide the ctx path from url
+		return refererPath.startsWith(ctxPath) ? refererPath.substring(ctxPath.length()) : refererPath;
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -94,19 +94,19 @@ public class DefaultRefererResult implements RefererResult {
 	}
 
 	private String getReferer() {
-		String referer = request.getHeader("Referer");
-		checkState(referer != null, "The Referer header was not specified");
-
-		String refererPath = null;
+	    String referer = request.getHeader("Referer");
+	    checkState(referer != null, "The Referer header was not specified");
+	    
+	    String refererPath = referer;
 		try {
-			refererPath = new URL(referer).getPath();
+		    refererPath = new URL(referer).getPath();
 		} catch(MalformedURLException e) {
-			//Maybe a relative path?
-			refererPath = referer;
+		    //Maybe a relative path?
+		    refererPath = referer;
 		}
-		
-		String ctxPath = request.getContextPath();
-		return refererPath.substring(refererPath.indexOf(ctxPath) + ctxPath.length());
+
+		String path = request.getContextPath();
+		return refererPath.substring(refererPath.indexOf(path) + path.length());
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -21,6 +21,8 @@ import static br.com.caelum.vraptor.view.Results.logic;
 import static br.com.caelum.vraptor.view.Results.page;
 import static com.google.common.base.Preconditions.checkState;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 
 import javax.enterprise.context.RequestScoped;
@@ -92,11 +94,19 @@ public class DefaultRefererResult implements RefererResult {
 	}
 
 	private String getReferer() {
-		String referer = request.getHeader("Referer");
-		checkState(referer != null, "The Referer header was not specified");
+	    String referer = request.getHeader("Referer");
+	    checkState(referer != null, "The Referer header was not specified");
+	    
+	    String refererPath = referer;
+		try {
+		    refererPath = new URL(referer).getPath();
+		} catch(MalformedURLException e) {
+		    //Maybe a relative path?
+		    refererPath = referer;
+		}
 
 		String path = request.getContextPath();
-		return referer.substring(referer.indexOf(path) + path.length());
+		return refererPath.substring(refererPath.indexOf(path) + path.length());
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -108,7 +108,7 @@ public class DefaultRefererResult implements RefererResult {
 		
 		//if the context path is not in the beggining we should return the entire path
 		//this is useful for proxied app servers which hide the ctx path from url
-		return refererPath.startsWith(ctxPath) ? refererPath.substring(ctxPath.length()) : refererPath;
+		return refererPath.startsWith(ctxPath+"/") || refererPath.equals(ctxPath) ? refererPath.substring(ctxPath.length()) : refererPath;
 	}
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -94,19 +94,19 @@ public class DefaultRefererResult implements RefererResult {
 	}
 
 	private String getReferer() {
-	    String referer = request.getHeader("Referer");
-	    checkState(referer != null, "The Referer header was not specified");
-	    
-	    String refererPath = referer;
-		try {
-		    refererPath = new URL(referer).getPath();
-		} catch(MalformedURLException e) {
-		    //Maybe a relative path?
-		    refererPath = referer;
-		}
+		String referer = request.getHeader("Referer");
+		checkState(referer != null, "The Referer header was not specified");
 
-		String path = request.getContextPath();
-		return refererPath.substring(refererPath.indexOf(path) + path.length());
+		String refererPath = null;
+		try {
+			refererPath = new URL(referer).getPath();
+		} catch(MalformedURLException e) {
+			//Maybe a relative path?
+			refererPath = referer;
+		}
+		
+		String ctxPath = request.getContextPath();
+		return refererPath.substring(refererPath.indexOf(ctxPath) + ctxPath.length());
 	}
 
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -17,6 +17,7 @@ package br.com.caelum.vraptor.view;
 
 import static br.com.caelum.vraptor.view.Results.logic;
 import static br.com.caelum.vraptor.view.Results.page;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -152,87 +153,22 @@ public class DefaultRefererResultTest {
 	}
 	
 	@Test
-	public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
-		LogicResult logic = mock(LogicResult.class);
-		RefererController controller = mock(RefererController.class);
-		
-		Method index = RefererController.class.getMethod("index");
-		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-		
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-		when(request.getContextPath()).thenReturn("/vrap");
-		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-		
-		doReturn(logic).when(result).use(logic());
-		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
-		
-		refererResult.redirect();
-		
-		verify(logic).redirectTo(RefererController.class);
-		verify(controller).index();
-	}
+	public void getRefererShouldReturnCorrectValue() throws Exception {
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/test/anything/ok"); //Regular case
+		when(request.getContextPath()).thenReturn("/test");
+		assertEquals("/anything/ok", refererResult.getReferer());
 
-	@Test
-	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
-		LogicResult logic = mock(LogicResult.class);
-		RefererController controller = mock(RefererController.class);
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/anything/ok/test"); //URL without context path (it appears in the path but not in in the right place)
+		when(request.getContextPath()).thenReturn("/test");
+		assertEquals("/anything/ok/test", refererResult.getReferer());
 		
-		Method index = RefererController.class.getMethod("index");
-		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-		
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/vrap/anything/ok"); //URL host starts with ctx path string (/vrap)
 		when(request.getContextPath()).thenReturn("/vrap");
-		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		assertEquals("/anything/ok", refererResult.getReferer());
 		
-		doReturn(logic).when(result).use(logic());
-		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
-		
-		refererResult.forward();
-		
-		verify(logic).forwardTo(RefererController.class);
-		verify(controller).index();
-	}
-	
-	@Test
-	public void whenRefererDoesNotContainsCtxPathItShouldRedirectCorrectly() throws Exception {
-		LogicResult logic = mock(LogicResult.class);
-		RefererController controller = mock(RefererController.class);
-		
-		Method index = RefererController.class.getMethod("index");
-		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-		
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/anything/ok");
+		when(request.getHeader("Referer")).thenReturn("/vrap/anything/ok/vrap"); //relative path in the referer (not common but predicted by http spec)
 		when(request.getContextPath()).thenReturn("/vrap");
-		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-		
-		doReturn(logic).when(result).use(logic());
-		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
-		
-		refererResult.redirect();
-		
-		verify(logic).redirectTo(RefererController.class);
-		verify(controller).index();
-	}
-	
-	@Test
-	public void whenRefererDoesNotContainsCtxPathItShouldForwardCorrectly() throws Exception {
-		LogicResult logic = mock(LogicResult.class);
-		RefererController controller = mock(RefererController.class);
-		
-		Method index = RefererController.class.getMethod("index");
-		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-		
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/anything/ok");
-		when(request.getContextPath()).thenReturn("/vrap");
-		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-		
-		doReturn(logic).when(result).use(logic());
-		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
-		
-		refererResult.forward();
-		
-		verify(logic).forwardTo(RefererController.class);
-		verify(controller).index();
+		assertEquals("/anything/ok/vrap", refererResult.getReferer());
 	}
 	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -153,29 +153,29 @@ public class DefaultRefererResultTest {
 	}
 	
 	@Test
-	public void getRefererShouldReturnCorrectValueInRegularCase() throws Exception {
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/test/anything/ok"); //Regular case
+	public void whenCtxPathAppearsInItsPlaceRefererShouldBeReturnedCorrectly() throws Exception {
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/test/anything/ok");
 		when(request.getContextPath()).thenReturn("/test");
 		assertEquals("/anything/ok", refererResult.getReferer());
 	}
 		
 	@Test
 	public void whenCtxPathAppearsAmongURLButNotInRightPlaceRefererShouldBeReturnedCorrectly() throws Exception {
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/vrapanything/ok/vrap/ok/vrap"); //ctx path appears among url path but without 'being itself'
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/vrapanything/ok/vrap/ok/vrap");
 		when(request.getContextPath()).thenReturn("/vrap");
 		assertEquals("/vrapanything/ok/vrap/ok/vrap", refererResult.getReferer());
 	}
 	
 	@Test
 	public void whenCtxPathEqualsURLPathRefererShouldBeReturnedCorrectly() throws Exception {
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/vrap/"); //url path equals ctx path
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/vrap/");
 		when(request.getContextPath()).thenReturn("/vrap");
 		assertEquals("/", refererResult.getReferer());
 	}
 	
 	@Test
 	public void whenRefererIsARelativePathRefererShouldBeReturnedCorrectly() throws Exception {
-		when(request.getHeader("Referer")).thenReturn("/vrap/anything/ok/vrap"); //relative path in the referer (not common but predicted by http spec)
+		when(request.getHeader("Referer")).thenReturn("/vrap/anything/ok/vrap");
 		when(request.getContextPath()).thenReturn("/vrap");
 		assertEquals("/anything/ok/vrap", refererResult.getReferer());
 	}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -153,44 +153,44 @@ public class DefaultRefererResultTest {
 	
 	@Test
     public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
-		LogicResult logic = mock(LogicResult.class);
-		RefererController controller = mock(RefererController.class);
-		
-		Method index = RefererController.class.getMethod("index");
-		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-		
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-		when(request.getContextPath()).thenReturn("/vrap");
-		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-		
-		doReturn(logic).when(result).use(logic());
-		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
-		
-		refererResult.redirect();
-		
-		verify(logic).redirectTo(RefererController.class);
-		verify(controller).index();
+        LogicResult logic = mock(LogicResult.class);
+        RefererController controller = mock(RefererController.class);
+
+        Method index = RefererController.class.getMethod("index");
+        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+        
+        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+        when(request.getContextPath()).thenReturn("/vrap");
+        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+        
+        doReturn(logic).when(result).use(logic());
+        when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+        
+        refererResult.redirect();
+        
+        verify(logic).redirectTo(RefererController.class);
+        verify(controller).index();
     }
 	
 	@Test
 	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
-		LogicResult logic = mock(LogicResult.class);
-		RefererController controller = mock(RefererController.class);
-
-		Method index = RefererController.class.getMethod("index");
-		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-		when(request.getContextPath()).thenReturn("/vrap");
-		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-		
-		doReturn(logic).when(result).use(logic());
-		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
-		
-		refererResult.forward();
-		
-		verify(logic).forwardTo(RefererController.class);
-		verify(controller).index();
+	    LogicResult logic = mock(LogicResult.class);
+        RefererController controller = mock(RefererController.class);
+        
+        Method index = RefererController.class.getMethod("index");
+        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+        
+        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+        when(request.getContextPath()).thenReturn("/vrap");
+        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+        
+        doReturn(logic).when(result).use(logic());
+        when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+        
+        refererResult.forward();
+        
+        verify(logic).forwardTo(RefererController.class);
+        verify(controller).index();
 	}
 	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -150,47 +150,4 @@ public class DefaultRefererResultTest {
 		verify(logic).forwardTo(RefererController.class);
 		verify(controller).index();
 	}
-	
-	@Test
-    public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
-        LogicResult logic = mock(LogicResult.class);
-        RefererController controller = mock(RefererController.class);
-
-        Method index = RefererController.class.getMethod("index");
-        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-        
-        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-        when(request.getContextPath()).thenReturn("/vrap");
-        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-        
-        doReturn(logic).when(result).use(logic());
-        when(logic.redirectTo(RefererController.class)).thenReturn(controller);
-        
-        refererResult.redirect();
-        
-        verify(logic).redirectTo(RefererController.class);
-        verify(controller).index();
-    }
-	
-	@Test
-	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
-	    LogicResult logic = mock(LogicResult.class);
-        RefererController controller = mock(RefererController.class);
-        
-        Method index = RefererController.class.getMethod("index");
-        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-        
-        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-        when(request.getContextPath()).thenReturn("/vrap");
-        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-        
-        doReturn(logic).when(result).use(logic());
-        when(logic.forwardTo(RefererController.class)).thenReturn(controller);
-        
-        refererResult.forward();
-        
-        verify(logic).forwardTo(RefererController.class);
-        verify(controller).index();
-	}
-	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -150,4 +150,47 @@ public class DefaultRefererResultTest {
 		verify(logic).forwardTo(RefererController.class);
 		verify(controller).index();
 	}
+	
+	@Test
+    public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
+        LogicResult logic = mock(LogicResult.class);
+        RefererController controller = mock(RefererController.class);
+
+        Method index = RefererController.class.getMethod("index");
+        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+        
+        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+        when(request.getContextPath()).thenReturn("/vrap");
+        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+        
+        doReturn(logic).when(result).use(logic());
+        when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+        
+        refererResult.redirect();
+        
+        verify(logic).redirectTo(RefererController.class);
+        verify(controller).index();
+    }
+	
+	@Test
+	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
+	    LogicResult logic = mock(LogicResult.class);
+        RefererController controller = mock(RefererController.class);
+        
+        Method index = RefererController.class.getMethod("index");
+        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+        
+        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+        when(request.getContextPath()).thenReturn("/vrap");
+        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+        
+        doReturn(logic).when(result).use(logic());
+        when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+        
+        refererResult.forward();
+        
+        verify(logic).forwardTo(RefererController.class);
+        verify(controller).index();
+	}
+	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -153,19 +153,28 @@ public class DefaultRefererResultTest {
 	}
 	
 	@Test
-	public void getRefererShouldReturnCorrectValue() throws Exception {
+	public void getRefererShouldReturnCorrectValueInRegularCase() throws Exception {
 		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/test/anything/ok"); //Regular case
 		when(request.getContextPath()).thenReturn("/test");
 		assertEquals("/anything/ok", refererResult.getReferer());
-
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/anything/ok/test"); //URL without context path (it appears in the path but not in in the right place)
-		when(request.getContextPath()).thenReturn("/test");
-		assertEquals("/anything/ok/test", refererResult.getReferer());
+	}
 		
-		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/vrap/anything/ok"); //URL host starts with ctx path string (/vrap)
+	@Test
+	public void whenCtxPathAppearsAmongURLButNotInRightPlaceRefererShouldBeReturnedCorrectly() throws Exception {
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/vrapanything/ok/vrap/ok/vrap"); //ctx path appears among url path but without 'being itself'
 		when(request.getContextPath()).thenReturn("/vrap");
-		assertEquals("/anything/ok", refererResult.getReferer());
-		
+		assertEquals("/vrapanything/ok/vrap/ok/vrap", refererResult.getReferer());
+	}
+	
+	@Test
+	public void whenCtxPathEqualsURLPathRefererShouldBeReturnedCorrectly() throws Exception {
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.caelum.com.br/vrap/"); //url path equals ctx path
+		when(request.getContextPath()).thenReturn("/vrap");
+		assertEquals("/", refererResult.getReferer());
+	}
+	
+	@Test
+	public void whenRefererIsARelativePathRefererShouldBeReturnedCorrectly() throws Exception {
 		when(request.getHeader("Referer")).thenReturn("/vrap/anything/ok/vrap"); //relative path in the referer (not common but predicted by http spec)
 		when(request.getContextPath()).thenReturn("/vrap");
 		assertEquals("/anything/ok/vrap", refererResult.getReferer());

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -150,4 +150,47 @@ public class DefaultRefererResultTest {
 		verify(logic).forwardTo(RefererController.class);
 		verify(controller).index();
 	}
+	
+	@Test
+	public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.redirect();
+		
+		verify(logic).redirectTo(RefererController.class);
+		verify(controller).index();
+	}
+
+	@Test
+	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.forward();
+		
+		verify(logic).forwardTo(RefererController.class);
+		verify(controller).index();
+	}
+	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -153,44 +153,44 @@ public class DefaultRefererResultTest {
 	
 	@Test
     public void whenRefererContainsCtxPathStrInTheHostItShouldRedirectCorrectly() throws Exception {
-        LogicResult logic = mock(LogicResult.class);
-        RefererController controller = mock(RefererController.class);
-
-        Method index = RefererController.class.getMethod("index");
-        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-        
-        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-        when(request.getContextPath()).thenReturn("/vrap");
-        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-        
-        doReturn(logic).when(result).use(logic());
-        when(logic.redirectTo(RefererController.class)).thenReturn(controller);
-        
-        refererResult.redirect();
-        
-        verify(logic).redirectTo(RefererController.class);
-        verify(controller).index();
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.redirect();
+		
+		verify(logic).redirectTo(RefererController.class);
+		verify(controller).index();
     }
 	
 	@Test
 	public void whenRefererContainsCtxPathStrInTheHostItShouldForwardCorrectly() throws Exception {
-	    LogicResult logic = mock(LogicResult.class);
-        RefererController controller = mock(RefererController.class);
-        
-        Method index = RefererController.class.getMethod("index");
-        ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
-        
-        when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
-        when(request.getContextPath()).thenReturn("/vrap");
-        when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
-        
-        doReturn(logic).when(result).use(logic());
-        when(logic.forwardTo(RefererController.class)).thenReturn(controller);
-        
-        refererResult.forward();
-        
-        verify(logic).forwardTo(RefererController.class);
-        verify(controller).index();
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/vrap/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.forward();
+		
+		verify(logic).forwardTo(RefererController.class);
+		verify(controller).index();
 	}
 	
 }

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/view/DefaultRefererResultTest.java
@@ -193,4 +193,46 @@ public class DefaultRefererResultTest {
 		verify(controller).index();
 	}
 	
+	@Test
+	public void whenRefererDoesNotContainsCtxPathItShouldRedirectCorrectly() throws Exception {
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.redirectTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.redirect();
+		
+		verify(logic).redirectTo(RefererController.class);
+		verify(controller).index();
+	}
+	
+	@Test
+	public void whenRefererDoesNotContainsCtxPathItShouldForwardCorrectly() throws Exception {
+		LogicResult logic = mock(LogicResult.class);
+		RefererController controller = mock(RefererController.class);
+		
+		Method index = RefererController.class.getMethod("index");
+		ControllerMethod method = DefaultControllerMethod.instanceFor(RefererController.class, index);
+		
+		when(request.getHeader("Referer")).thenReturn("http://vraptor.test.com/anything/ok");
+		when(request.getContextPath()).thenReturn("/vrap");
+		when(router.parse("/anything/ok", HttpMethod.GET, request)).thenReturn(method);
+		
+		doReturn(logic).when(result).use(logic());
+		when(logic.forwardTo(RefererController.class)).thenReturn(controller);
+		
+		refererResult.forward();
+		
+		verify(logic).forwardTo(RefererController.class);
+		verify(controller).index();
+	}
+	
 }


### PR DESCRIPTION
Relaxing getReferer() visibility to 'protected' in order to unit test it
directly; replacing several test methods for referer check with
redirect/forward with a single method that tests the getReferer()
returned value in various situations