### PR TITLE
don't log exception on missing bundle for base name messages

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/JstlLocalization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/JstlLocalization.java
@@ -77,7 +77,7 @@ public class JstlLocalization {
 			try {
 				return ResourceBundle.getBundle(baseName, locale);
 			} catch (MissingResourceException e) {
-				logger.warn("couldn't find message bundle, creating an empty one", e);
+				logger.warn("couldn't find message bundle, creating an empty one");
 				return new EmptyBundle();
 			}
 		}


### PR DESCRIPTION
Small patch do avoid log exception on missing bundle for base name messages.