### PR TITLE
Fix Get Adapters in Proxy Class

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonBuilderWrapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonBuilderWrapper.java
@@ -90,9 +90,20 @@ public class GsonBuilderWrapper implements GsonSerializerBuilder, GsonDeserializ
 	}
 	
 	private Class<?> getAdapterType(Object adapter) {
-		Type[] genericInterfaces = adapter.getClass().getGenericInterfaces();
-		ParameterizedType type = (ParameterizedType) genericInterfaces[0];
-		Type actualType = type.getActualTypeArguments()[0];
+		final Class<?> klazz;
+		if(adapter.getClass().getName().contains("$Proxy$")){
+			final String[] split = adapter.getClass().getName().split("\\$Proxy\\$");
+			try {
+				klazz = Class.forName(split[0]);
+			} catch (final ClassNotFoundException e) {
+				throw new RuntimeException(e);
+			}
+		}else{
+			klazz = adapter.getClass();
+		}
+		final Type[] genericInterfaces = klazz.getGenericInterfaces();
+		final ParameterizedType type = (ParameterizedType) genericInterfaces[0];
+		final Type actualType = type.getActualTypeArguments()[0];
 
 		if (actualType instanceof ParameterizedType) {
 			return (Class<?>) ((ParameterizedType) actualType).getRawType();

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonBuilderWrapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonBuilderWrapper.java
@@ -15,6 +15,7 @@
  */
 package br.com.caelum.vraptor.serialization.gson;
 
+import static br.com.caelum.vraptor.proxy.CDIProxies.isCDIProxy;
 import static java.util.Collections.singletonList;
 
 import java.lang.reflect.ParameterizedType;
@@ -26,14 +27,14 @@ import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
-import br.com.caelum.vraptor.core.ReflectionProvider;
-import br.com.caelum.vraptor.serialization.Serializee;
-
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonSerializer;
+
+import br.com.caelum.vraptor.core.ReflectionProvider;
+import br.com.caelum.vraptor.serialization.Serializee;
 
 /**
  * Builder Wrapper for JSON using GSON.
@@ -91,7 +92,7 @@ public class GsonBuilderWrapper implements GsonSerializerBuilder, GsonDeserializ
 	
 	private Class<?> getAdapterType(Object adapter) {
 		final Class<?> klazz;
-		if(adapter.getClass().getName().contains("$Proxy$")){
+		if(isCDIProxy(adapter.getClass())){
 			final String[] split = adapter.getClass().getName().split("\\$Proxy\\$");
 			try {
 				klazz = Class.forName(split[0]);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonBuilderWrapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonBuilderWrapper.java
@@ -15,7 +15,7 @@
  */
 package br.com.caelum.vraptor.serialization.gson;
 
-import static br.com.caelum.vraptor.proxy.CDIProxies.isCDIProxy;
+import static br.com.caelum.vraptor.proxy.CDIProxies.extractRawTypeIfPossible;
 import static java.util.Collections.singletonList;
 
 import java.lang.reflect.ParameterizedType;
@@ -91,17 +91,7 @@ public class GsonBuilderWrapper implements GsonSerializerBuilder, GsonDeserializ
 	}
 	
 	private Class<?> getAdapterType(Object adapter) {
-		final Class<?> klazz;
-		if(isCDIProxy(adapter.getClass())){
-			final String[] split = adapter.getClass().getName().split("\\$Proxy\\$");
-			try {
-				klazz = Class.forName(split[0]);
-			} catch (final ClassNotFoundException e) {
-				throw new RuntimeException(e);
-			}
-		}else{
-			klazz = adapter.getClass();
-		}
+		final Class<?> klazz = extractRawTypeIfPossible(adapter.getClass());
 		final Type[] genericInterfaces = klazz.getGenericInterfaces();
 		final ParameterizedType type = (ParameterizedType) genericInterfaces[0];
 		final Type actualType = type.getActualTypeArguments()[0];

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/gson/GsonBuilderWrapperTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/gson/GsonBuilderWrapperTest.java
@@ -1,0 +1,56 @@
+package br.com.caelum.vraptor.serialization.gson;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Type;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import br.com.caelum.vraptor.WeldJunitRunner;
+
+@RunWith(WeldJunitRunner.class)
+public class GsonBuilderWrapperTest {
+	private @Inject GsonBuilderWrapper builder;
+	private Gson gson;
+	
+	@Before
+	public void init(){
+		gson = builder.create();
+	}
+	
+	@Test
+	public void test() {
+		String json = gson.toJson(new Bean());
+		assertEquals("{\"test123\":{}}", json);
+	}
+}
+
+class Bean{
+	
+}
+
+
+@RegisterStrategy(RegisterType.SINGLE)
+@RequestScoped
+class BeanSerializer implements JsonSerializer<Bean> {
+	private static final JsonObject element = new JsonObject();
+	static{
+		element.add("test123", new JsonObject());
+	}
+	
+	@Override
+	public JsonElement serialize(Bean src, Type typeOfSrc, JsonSerializationContext context) {
+		return element;
+	}
+}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/gson/GsonDeserializerTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/gson/GsonDeserializerTest.java
@@ -169,6 +169,9 @@ public class GsonDeserializerTest {
 			return dog;
 		}
 	}
+	
+	private class DogDeserializer$Proxy$$somentigin extends DogDeserializer implements JsonDeserializer<Dog> {
+	}
 
 	static class DogGenericController extends GenericController<Dog> {
 
@@ -262,6 +265,27 @@ public class GsonDeserializerTest {
 		List<JsonDeserializer<?>> deserializers = new ArrayList<>();
 		List<JsonSerializer<?>> serializers = new ArrayList<>();
 		deserializers.add(new DogDeserializer());
+
+		builder = new GsonBuilderWrapper(new MockInstanceImpl<>(serializers), new MockInstanceImpl<>(deserializers), 
+				new Serializee(new DefaultReflectionProvider()), new DefaultReflectionProvider());
+		deserializer = new GsonDeserialization(builder, provider, request, container, deserializeeInstance);
+
+		InputStream stream = asStream("{'dog':{'name':'Renan Reis','age':'0'}}");
+
+		Object[] deserialized = deserializer.deserialize(stream, dogParameter);
+
+		assertThat(deserialized.length, is(1));
+		assertThat(deserialized[0], is(instanceOf(Dog.class)));
+		Dog dog = (Dog) deserialized[0];
+		assertThat(dog.name, is("Renan"));
+		assertThat(dog.age, is(25));
+	}
+
+	@Test
+	public void shouldBeAbleToDeserializeADogWithCdiProxyAdapter() throws Exception {
+		List<JsonDeserializer<?>> deserializers = new ArrayList<>();
+		List<JsonSerializer<?>> serializers = new ArrayList<>();
+		deserializers.add(new DogDeserializer$Proxy$$somentigin());
 
 		builder = new GsonBuilderWrapper(new MockInstanceImpl<>(serializers), new MockInstanceImpl<>(deserializers), 
 				new Serializee(new DefaultReflectionProvider()), new DefaultReflectionProvider());

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/gson/GsonDeserializerTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/serialization/gson/GsonDeserializerTest.java
@@ -40,14 +40,18 @@ import java.util.TimeZone;
 import javax.enterprise.inject.Instance;
 import javax.servlet.http.HttpServletRequest;
 
-import net.vidageek.mirror.dsl.Mirror;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializer;
 
 import br.com.caelum.vraptor.Consumes;
 import br.com.caelum.vraptor.controller.BeanClass;
@@ -62,12 +66,7 @@ import br.com.caelum.vraptor.serialization.Deserializee;
 import br.com.caelum.vraptor.serialization.Serializee;
 import br.com.caelum.vraptor.util.test.MockInstanceImpl;
 import br.com.caelum.vraptor.view.GenericController;
-
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonSerializer;
+import net.vidageek.mirror.dsl.Mirror;
 
 public class GsonDeserializerTest {
 
@@ -169,9 +168,6 @@ public class GsonDeserializerTest {
 			return dog;
 		}
 	}
-	
-	private class DogDeserializer$Proxy$$somentigin extends DogDeserializer implements JsonDeserializer<Dog> {
-	}
 
 	static class DogGenericController extends GenericController<Dog> {
 
@@ -265,27 +261,6 @@ public class GsonDeserializerTest {
 		List<JsonDeserializer<?>> deserializers = new ArrayList<>();
 		List<JsonSerializer<?>> serializers = new ArrayList<>();
 		deserializers.add(new DogDeserializer());
-
-		builder = new GsonBuilderWrapper(new MockInstanceImpl<>(serializers), new MockInstanceImpl<>(deserializers), 
-				new Serializee(new DefaultReflectionProvider()), new DefaultReflectionProvider());
-		deserializer = new GsonDeserialization(builder, provider, request, container, deserializeeInstance);
-
-		InputStream stream = asStream("{'dog':{'name':'Renan Reis','age':'0'}}");
-
-		Object[] deserialized = deserializer.deserialize(stream, dogParameter);
-
-		assertThat(deserialized.length, is(1));
-		assertThat(deserialized[0], is(instanceOf(Dog.class)));
-		Dog dog = (Dog) deserialized[0];
-		assertThat(dog.name, is("Renan"));
-		assertThat(dog.age, is(25));
-	}
-
-	@Test
-	public void shouldBeAbleToDeserializeADogWithCdiProxyAdapter() throws Exception {
-		List<JsonDeserializer<?>> deserializers = new ArrayList<>();
-		List<JsonSerializer<?>> serializers = new ArrayList<>();
-		deserializers.add(new DogDeserializer$Proxy$$somentigin());
 
 		builder = new GsonBuilderWrapper(new MockInstanceImpl<>(serializers), new MockInstanceImpl<>(deserializers), 
 				new Serializee(new DefaultReflectionProvider()), new DefaultReflectionProvider());


### PR DESCRIPTION
Possible create Serializers without producers, Before throw a expcetion:
```java
java.lang.ClassCastException: java.lang.Class cannot be cast to java.lang.reflect.ParameterizedType
	at br.com.caelum.vraptor.serialization.gson.GsonBuilderWrapper.getAdapterType(GsonBuilderWrapper.java:99)
	at br.com.caelum.vraptor.serialization.gson.GsonBuilderWrapper.create(GsonBuilderWrapper.java:74)
	at br.com.caelum.vraptor.serialization.gson.GsonDeserialization.deserialize(GsonDeserialization.java:95)
	at br.com.caelum.vraptor.serialization.gson.GsonDeserialization$Proxy$_$$_WeldClientProxy.deserialize(Unknown Source)
	at br.com.caelum.vraptor.observer.DeserializingObserver.deserializes(DeserializingObserver.java:96)
```