### PR TITLE
Refactoring null check at MethodInfo

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/MethodInfo.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/MethodInfo.java
@@ -96,13 +96,11 @@ public class MethodInfo {
 	}
 
 	private void createValuedParameter(ControllerMethod controllerMethod) {
-		if (valuedParameters == null) {
+		if (valuedParameters == null && controllerMethod != null && controllerMethod.getMethod() != null) {
 			valuedParameters = new ValuedParameter[controllerMethod.getArity()];
-			if (controllerMethod != null && controllerMethod.getMethod() != null) {
-				Parameter[] parameters = parameterNameProvider.parametersFor(controllerMethod.getMethod());
-				for (int i = 0; i < valuedParameters.length; i++) {
-					valuedParameters[i] = new ValuedParameter(parameters[i], null);
-				}
+			Parameter[] parameters = parameterNameProvider.parametersFor(controllerMethod.getMethod());
+			for (int i = 0; i < valuedParameters.length; i++) {
+				valuedParameters[i] = new ValuedParameter(parameters[i], null);
 			}
 		}
 	}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/core/MethodInfoTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/core/MethodInfoTest.java
@@ -22,9 +22,9 @@ public class MethodInfoTest {
 	public void setUp() {
 		this.methodInfo = new MethodInfo(new ParanamerNameProvider());
 	}
-	
+
 	@Test
-	public void should_clear_valued_parameters_when_controller_method_is_updated() {
+	public void shouldClearValuedParametersWhenControllerMethodIsUpdated() {
 		ValuedParameter[] parameters = null;
 		methodInfo.setControllerMethod(controllerMethod("bark", int.class));
 		parameters = methodInfo.getValuedParameters();

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/core/MethodInfoTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/core/MethodInfoTest.java
@@ -2,6 +2,7 @@ package br.com.caelum.vraptor.core;
 
 import static br.com.caelum.vraptor.controller.DefaultControllerMethod.instanceFor;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.lang.reflect.Method;
@@ -32,6 +33,11 @@ public class MethodInfoTest {
 		methodInfo.setControllerMethod(controllerMethod("bark", String.class));
 		parameters = methodInfo.getValuedParameters();
 		assertThat(parameters[0].getName(), is("phrase"));
+	}
+
+	@Test
+	public void shouldSkipWhenMethodNotDefined() {
+		assertThat(methodInfo.getValuedParameters(), is(nullValue()));
 	}
 
 	private ControllerMethod controllerMethod(String methodName, Class<?> clazz) {


### PR DESCRIPTION
Because at this time if `controllerMethod` is null, a NPE will throws because line 98 don't check null. The null check was done in the line 99.