### PR TITLE
Adding a null check to avoid NPE at CustomAcceptsVerifier

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/CustomAcceptsVerifier.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/CustomAcceptsVerifier.java
@@ -73,7 +73,7 @@ public class CustomAcceptsVerifier {
 		return new Predicate<Annotation>() {
 			@Override
 			public boolean apply(Annotation element) {
-				return element.annotationType().isAnnotationPresent(AcceptsConstraint.class);
+				return element != null && element.annotationType().isAnnotationPresent(AcceptsConstraint.class);
 			}
 		};
 	}


### PR DESCRIPTION
Because Predicate (from Guava) are annotated with `Nullable` and allow null values.