### PR TITLE
changing json without root message from info to warn

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonDeserialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonDeserialization.java
@@ -122,7 +122,7 @@ public class GsonDeserialization implements Deserializer {
 						
 						if (deserializee.isWithoutRoot()) { 
 							values[i] = gson.fromJson(root, fallbackTo(parameter.getParameterizedType(), types[i]));
-							logger.info("json without root deserialized");
+							logger.warn("json without root deserialized");
 							break;
 
 						} else if (node != null) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonDeserialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonDeserialization.java
@@ -122,7 +122,7 @@ public class GsonDeserialization implements Deserializer {
 						
 						if (deserializee.isWithoutRoot()) { 
 							values[i] = gson.fromJson(root, fallbackTo(parameter.getParameterizedType(), types[i]));
-							logger.warn("json without root deserialized");
+							logger.debug("json without root deserialized");
 							break;
 
 						} else if (node != null) {


### PR DESCRIPTION
IMO there is no reason to this log to be INFO instead of WARN. It's a common use to use JSON without root and it get's the log fully of unused messages.

What do you guys think about it? @Turini @lucascs @garcia-jj 