### PR TITLE
Code Quality Improvement - Exception handlers should preserve the original exception

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
@@ -101,7 +101,7 @@ public class DefaultEnvironment implements Environment {
 			properties.load(resource);
 			LOG.debug("File {}.properties loaded", environment);
 		} catch (NullPointerException | IOException whenNotFound) {
-			LOG.warn("Could not find the file " + environment + ".properties to load.");
+			LOG.warn("Could not find the file " + environment + ".properties to load.", whenNotFound);
 		}
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorInstantiator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorInstantiator.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
@@ -49,6 +52,8 @@ import com.google.common.collect.ImmutableList;
 
 @RequestScoped
 public class VRaptorInstantiator implements InstantiatorWithErrors, Instantiator<Object> {
+	
+	private static final Logger logger = LoggerFactory.getLogger(VRaptorInstantiator.class);
 	
 	private MultiInstantiator multiInstantiator;
 	private List<Message> errors;
@@ -164,8 +169,10 @@ public class VRaptorInstantiator implements InstantiatorWithErrors, Instantiator
 				
 				return converterForTarget(target).convert(parameter.getValue(), target.getClassType());
 			} catch (ConversionException ex) {
+				logger.debug("Could not convert target", ex);
 				errors.add(ex.getValidationMessage().withCategory(target.getName()));
 			} catch (IllegalStateException e) {
+				logger.debug("An error occured while getting validation message", e);
 				return setPropertiesAfterConversions(target, parameters);
 			}
 			return null;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultParametersControl.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultParametersControl.java
@@ -50,7 +50,7 @@ import br.com.caelum.vraptor.util.StringUtils;
 @Vetoed
 public class DefaultParametersControl implements ParametersControl {
 
-	private final Logger logger = LoggerFactory.getLogger(DefaultParametersControl.class);
+	private static final Logger logger = LoggerFactory.getLogger(DefaultParametersControl.class);
 	private final List<String> parameters = new ArrayList<>();
 	private final Pattern pattern;
 	private final String originalPattern;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/FlashInterceptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/FlashInterceptor.java
@@ -90,7 +90,7 @@ public class FlashInterceptor implements Interceptor {
 						session.setAttribute(FLASH_INCLUDED_PARAMETERS, new HashMap<>(included));
 					} catch (IllegalStateException e) {
 						LOGGER.warn("HTTP Session was invalidated. It is not possible to include " +
-								"Result parameters on Flash Scope");
+								"Result parameters on Flash Scope", e);
 					}
 				}
 			}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/RequestHandlerObserver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/RequestHandlerObserver.java
@@ -93,12 +93,13 @@ public class RequestHandlerObserver {
 			interceptorStack.start();
 			endRequestEvent.fire(new RequestSucceded(request, response));
 		} catch (ControllerNotFoundException e) {
+			LOGGER.debug("Could not found controller method", e);
 			controllerNotFoundHandler.couldntFind(event.getChain(), request, response);
 		} catch (MethodNotAllowedException e) {
-			LOGGER.debug(e.getMessage(), e);
+			LOGGER.debug("Method is not allowed", e);
 			methodNotAllowedHandler.deny(request, response, e.getAllowedMethods());
 		} catch (InvalidInputException e) {
-			LOGGER.debug(e.getMessage(), e);
+			LOGGER.debug("Invalid input", e);
 			invalidInputHandler.deny(e);
 		}
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/CommonsUploadMultipartObserver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/CommonsUploadMultipartObserver.java
@@ -151,7 +151,7 @@ public class CommonsUploadMultipartObserver {
 			try {
 				return item.getString(encoding);
 			} catch (UnsupportedEncodingException e) {
-				logger.warn("Request have an invalid encoding. Ignoring it");
+				logger.debug("Request has an invalid encoding. Ignoring it", e);
 			}
 		}
 		return item.getString();

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/SafeResourceBundle.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/SafeResourceBundle.java
@@ -23,6 +23,9 @@ import java.util.ResourceBundle;
 
 import javax.enterprise.inject.Vetoed;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A Resource bundle that doesn't throw exception when there is no resource of given key.
  * It only returns ??? + key + ??? when the key doesn't exist.
@@ -33,6 +36,7 @@ import javax.enterprise.inject.Vetoed;
 @Vetoed
 public class SafeResourceBundle extends ResourceBundle {
 
+	private static final Logger logger = LoggerFactory.getLogger(SafeResourceBundle.class);
 	private final ResourceBundle delegate;
 	private final boolean isDefault;
 
@@ -59,6 +63,7 @@ public class SafeResourceBundle extends ResourceBundle {
 		try {
 			return delegate.getString(key);
 		} catch (MissingResourceException e) {
+			logger.warn("Resource missed while calling delegate", e);
 			return "???" + key + "???";
 		}
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -39,9 +39,14 @@ import br.com.caelum.vraptor.http.route.MethodNotAllowedException;
 import br.com.caelum.vraptor.http.route.Router;
 import br.com.caelum.vraptor.validator.Message;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @RequestScoped
 public class DefaultRefererResult implements RefererResult {
-
+	
+	private static final Logger logger = LoggerFactory.getLogger(DefaultRefererResult.class);
+	
 	private final MutableRequest request;
 	private final Result result;
 	private final Router router;
@@ -73,6 +78,7 @@ public class DefaultRefererResult implements RefererResult {
 			ControllerMethod method = router.parse(referer, HttpMethod.GET, request);
 			executeMethod(method, result.use(logic()).forwardTo(method.getController().getType()));
 		} catch (ControllerNotFoundException | MethodNotAllowedException e) {
+			logger.warn("Could not find or doesn't allowed to get controller method", e);
 			result.use(page()).forwardTo(referer);
 		}
 	}
@@ -89,6 +95,7 @@ public class DefaultRefererResult implements RefererResult {
 			ControllerMethod method = router.parse(referer, HttpMethod.GET, request);
 			executeMethod(method, result.use(logic()).redirectTo(method.getController().getType()));
 		} catch (ControllerNotFoundException | MethodNotAllowedException e) {
+			logger.warn("Could not find or doesn't allowed to get controller method", e);
 			result.use(page()).redirectTo(referer);
 		}
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/LinkToHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/LinkToHandler.java
@@ -155,6 +155,7 @@ public class LinkToHandler extends ForwardingMap<Class<?>, Object> {
 		try {
 			return Class.forName(interfaceName);
 		} catch (ClassNotFoundException e1) {
+			logger.warn("Could not find class", e1);
 			// ok, continue
 		}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1166 - “Exception handlers should preserve the original exception”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1166

Please let me know if you have any questions.

Christian