### PR TITLE
Code Quality Improvement - @Override annotation should be used on any…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/events/VRaptorRequestStarted.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/events/VRaptorRequestStarted.java
@@ -41,15 +41,15 @@ public class VRaptorRequestStarted implements RequestStarted {
 		this.request = request;
 		this.response = response;
 	}
-
+	@Override
 	public FilterChain getChain() {
 		return chain;
 	}
-
+	@Override
 	public MutableRequest getRequest() {
 		return request;
 	}
-
+	@Override
 	public MutableResponse getResponse() {
 		return response;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1161 - @Override annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1161.

Please let me know if you have any questions.

Christiane any questions.

Christian