### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/BigDecimalConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/BigDecimalConverter.java
@@ -73,7 +73,7 @@ public class BigDecimalConverter implements Converter<BigDecimal> {
 	}
 	
 	protected NumberFormat getNumberFormat() {
-		DecimalFormat fmt = ((DecimalFormat) DecimalFormat.getInstance(locale));
+		DecimalFormat fmt = (DecimalFormat) DecimalFormat.getInstance(locale);
 		fmt.setParseBigDecimal(true);
 		return fmt;
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DefaultTypeNameExtractor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DefaultTypeNameExtractor.java
@@ -47,7 +47,7 @@ public class DefaultTypeNameExtractor implements TypeNameExtractor {
 		}
 
 		if (generic instanceof TypeVariable<?>) {
-			return nameFor(((TypeVariable<?>) generic));
+			return nameFor((TypeVariable<?>) generic);
 		}
 
 		return nameFor((Class<?>) generic);
@@ -68,7 +68,7 @@ public class DefaultTypeNameExtractor implements TypeNameExtractor {
 	}
 
 	private String nameFor(WildcardType wild) {
-		if ((wild.getLowerBounds().length != 0)) {
+		if (wild.getLowerBounds().length != 0) {
 			return nameFor(wild.getLowerBounds()[0]);
 		} else {
 			return nameFor(wild.getUpperBounds()[0]);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/Exclusions.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/Exclusions.java
@@ -71,8 +71,8 @@ public class Exclusions implements ExclusionStrategy {
 	}
 
 	private boolean isCompatiblePath(Entry<String, Class<?>> path, Class<?> definedIn, String fieldName) {
-		return (path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || 
-				path.getKey().endsWith("." + fieldName)));
+		return path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || 
+				path.getKey().endsWith("." + fieldName));
 	}
 
 	@Override

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
@@ -78,7 +78,7 @@ public class VRaptorClassMapper extends MapperWrapper {
 	}
 
 	private boolean isCompatiblePath(Entry<String, Class<?>> path, Class definedIn, String fieldName) {
-		return (path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || path.getKey().endsWith("." + fieldName)));
+		return path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || path.getKey().endsWith("." + fieldName));
 	}
 
 	@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat