### PR TITLE
squid:S2162, squid:S1488 - equals methods should be symmetric and wor…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/Parameter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/Parameter.java
@@ -94,7 +94,7 @@ public class Parameter {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof Parameter) {
+		if (this.getClass() == obj.getClass()) {
 			Parameter other = (Parameter) obj;
 			return other.index == index && other.holder.equals(holder);
 		}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ValuedParameter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/ValuedParameter.java
@@ -58,7 +58,7 @@ public class ValuedParameter {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof ValuedParameter) {
+		if (this.getClass() == obj.getClass()) {
 			ValuedParameter other = (ValuedParameter) obj;
 			return Objects.equals(parameter.getName(), other.getParameter().getName())
 					&& Objects.equals(value, other.getValue());

--- a/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/dao/DefaultMusicDao.java
+++ b/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/dao/DefaultMusicDao.java
@@ -57,11 +57,10 @@ public class DefaultMusicDao implements MusicDao {
 
 	@Override
 	public List<Music> searchSimilarTitle(String title) {
-		List<Music> musics = entityManager
-			.createQuery("select m from Music m where lower(m.title) like lower(:title)", Music.class)
+		return musics = entityManager
+				.createQuery("select m from Music m where lower(m.title) like lower(:title)", Music.class)
 				.setParameter("title", "%" + title+ "%")
 				.getResultList();
-		return musics;
 	}
 	
 	@Override

--- a/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/dao/DefaultUserDao.java
+++ b/vraptor-musicjungle/src/main/java/br/com/caelum/vraptor/musicjungle/dao/DefaultUserDao.java
@@ -57,12 +57,11 @@ public class DefaultUserDao implements UserDao {
 	@Override
 	public User find(String login, String password) {
 		try {
-			User user = entityManager
-				.createQuery("select u from User u where u.login = :login and u.password = :password", User.class)
+			return entityManager
+					.createQuery("select u from User u where u.login = :login and u.password = :password", User.class)
 					.setParameter("login", login)
 					.setParameter("password", password)
 					.getSingleResult();
-			return user;
 		} catch (NoResultException e) {
 			return null;
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2162, squid:S1488 - equals methods should be symmetric and work for subclasses, Local Variables should not be declared and then immediately returned or thrown

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488

Please let me know if you have any questions.

M-Ezzat