### PR TITLE
squid:S2325 - "private" methods that dont access instance data should…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/BooleanConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/BooleanConverter.java
@@ -65,7 +65,7 @@ public class BooleanConverter implements Converter<Boolean> {
 		throw new ConversionException(new ConversionMessage(INVALID_MESSAGE_KEY, value));
 	}
 
-	private boolean matches(Set<String> words, String value) {
+	private static boolean matches(Set<String> words, String value) {
 		return words.contains(value);
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultExceptionMapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultExceptionMapper.java
@@ -87,7 +87,7 @@ public class DefaultExceptionMapper implements ExceptionMapper {
 		return hasExceptionCause(e) ? findByException((Exception) e.getCause()) : null;
 	}
 
-	private boolean hasExceptionCause(Exception e) {
+	private static boolean hasExceptionCause(Exception e) {
 		return e.getCause() != null && e.getCause() instanceof Exception;
 	}
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultStaticContentHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultStaticContentHandler.java
@@ -69,14 +69,14 @@ public class DefaultStaticContentHandler implements StaticContentHandler {
 		return removeQueryStringAndJSessionId(uri);
 	}
 
-	private String removeQueryStringAndJSessionId(String uri) {
+	private static String removeQueryStringAndJSessionId(String uri) {
 		if (uri.contains("?") || uri.contains(";")) {
 			return uri.replaceAll("[\\?;].+", "");
 		}
 		return uri;
 	}
 
-	private boolean isAFile(URL resourceUrl) {
+	private static boolean isAFile(URL resourceUrl) {
 		return !resourceUrl.toString().endsWith("/");
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
@@ -136,7 +136,7 @@ public class DefaultEnvironment implements Environment {
 	/**
 	 * Find environment name using {@code VRAPTOR_ENV} from system environment.
 	 */
-	private String fromSystemEnv() {
+	private static String fromSystemEnv() {
 		return System.getenv("VRAPTOR_ENV");
 	}
 
@@ -144,7 +144,7 @@ public class DefaultEnvironment implements Environment {
 	 * Find environment name using {@code br.com.caelum.vraptor.environment} from system property. To define this
 	 * you can start the application server using {@code -Dbr.com.caelum.vraptor.environment=DEVELOPMENT}.
 	 */
-	private String fromSystemProperty() {
+	private static String fromSystemProperty() {
 		return System.getProperty(ENVIRONMENT_PROPERTY);
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouteBuilder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouteBuilder.java
@@ -207,7 +207,7 @@ public class DefaultRouteBuilder implements RouteBuilder {
 		}
 	}
 
-	private String[] sanitize(String[] parameters) {
+	private static String[] sanitize(String[] parameters) {
 		String[] sanitized = new String[parameters.length];
 		for (int i = 0; i < parameters.length; i++) {
 			sanitized[i] = parameters[i].replaceAll("(\\:.*|\\*)$", "");

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/PathAnnotationRoutesParser.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/PathAnnotationRoutesParser.java
@@ -202,7 +202,7 @@ public class PathAnnotationRoutesParser implements RoutesParser {
 		}
 	}
 
-	private String fixLeadingSlash(String uri) {
+	private static String fixLeadingSlash(String uri) {
 		if (!uri.startsWith("/")) {
 			return  "/" + uri;
 		}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/DeserializingObserver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/DeserializingObserver.java
@@ -103,7 +103,7 @@ public class DeserializingObserver {
 		}
 	}
 
-	private String mime(String contentType) {
+	private static String mime(String contentType) {
 		if (contentType.contains(";")) {
 			return contentType.split(";")[0];
 		}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/download/FileDownload.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/download/FileDownload.java
@@ -65,7 +65,7 @@ public class FileDownload implements Download {
 		}
 	}
 	
-	private File checkFile(File file) throws FileNotFoundException {
+	private static File checkFile(File file) throws FileNotFoundException {
 		if (!file.exists()) {
 			throw new FileNotFoundException("File " + file.getName() + " doesn't exists");
 		}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/DefaultDeserializers.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/DefaultDeserializers.java
@@ -64,7 +64,7 @@ public class DefaultDeserializers implements Deserializers {
 		return null;
 	}
 
-	private String removeChar(String type, String by) {
+	private static String removeChar(String type, String by) {
 		return type.substring(type.lastIndexOf(by)+1);
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonDeserialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonDeserialization.java
@@ -157,7 +157,7 @@ public class GsonDeserialization implements Deserializer {
 		return values;
 	}
 
-	private Type fallbackTo(Type parameterizedType, Class<?> type) {
+	private static Type fallbackTo(Type parameterizedType, Class<?> type) {
 		if (parameterizedType instanceof TypeVariable) return type;
 		return parameterizedType;
 	}
@@ -174,7 +174,7 @@ public class GsonDeserialization implements Deserializer {
 		return charset.split(",")[0];
 	}
 
-	private boolean isWithoutRoot(Parameter[] parameters, JsonObject root) {
+	private static boolean isWithoutRoot(Parameter[] parameters, JsonObject root) {
 		for (Parameter parameter : parameters) {
 			if (root.get(parameter.getName()) != null)
 				return false;
@@ -192,7 +192,7 @@ public class GsonDeserialization implements Deserializer {
 		return parameterTypes;
 	}
 
-	private Class<?>[] parseGenericParameters(Class<?>[] parameterTypes,
+	private static Class<?>[] parseGenericParameters(Class<?>[] parameterTypes,
 			Type genericType) {
 		Class<?> type = (Class<?>) getGenericType(genericType);
 		for (int i = 0; i < parameterTypes.length; i++) {
@@ -203,7 +203,7 @@ public class GsonDeserialization implements Deserializer {
 		return parameterTypes;
 	}
 
-	private Type getGenericSuperClass(ControllerMethod method) {
+	private static Type getGenericSuperClass(ControllerMethod method) {
 		Type genericType = method.getController().getType().getGenericSuperclass();
 		if (genericType instanceof ParameterizedType) {
 			return genericType;
@@ -212,7 +212,7 @@ public class GsonDeserialization implements Deserializer {
 		return null;
 	}
 
-	private Type getGenericType(Type type) {
+	private static Type getGenericType(Type type) {
 		ParameterizedType paramType = (ParameterizedType) type;
 		return paramType.getActualTypeArguments()[0];
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/VRaptorClassMapper.java
@@ -77,7 +77,7 @@ public class VRaptorClassMapper extends MapperWrapper {
 		return should;
 	}
 
-	private boolean isCompatiblePath(Entry<String, Class<?>> path, Class definedIn, String fieldName) {
+	private static boolean isCompatiblePath(Entry<String, Class<?>> path, Class definedIn, String fieldName) {
 		return path.getValue().equals(definedIn) && (path.getKey().equals(fieldName) || path.getKey().endsWith("." + fieldName));
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamXMLDeserializer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamXMLDeserializer.java
@@ -85,7 +85,7 @@ public class XStreamXMLDeserializer implements Deserializer {
 		return xStream;
 	}
 
-	private void chooseParam(Class<?>[] types, Object[] params, Object deserialized) {
+	private static void chooseParam(Class<?>[] types, Object[] params, Object deserialized) {
 		for (int i = 0; i < types.length; i++) {
 			if (types[i].isInstance(deserialized)) {
 				params[i] = deserialized;

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultAcceptHeaderToFormat.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultAcceptHeaderToFormat.java
@@ -176,7 +176,7 @@ public class DefaultAcceptHeaderToFormat implements AcceptHeaderToFormat {
 		return new MimeType(string, 1);
 	}
 
-	private double extractQualifier(String string) {
+	private static double extractQualifier(String string) {
 		double qualifier = DEFAULT_QUALIFIER_VALUE;
 		if (string.contains("q=")) {
 			Matcher matcher = Pattern.compile("\\s*q=(.+)\\s*").matcher(string);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
@@ -88,7 +88,7 @@ public class DefaultPathResolver implements PathResolver {
 		return baseName;
 	}
 
-	private String lowerFirstCharacter(String baseName) {
+	private static String lowerFirstCharacter(String baseName) {
 		return baseName.toLowerCase().substring(0, 1) + baseName.substring(1, baseName.length());
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat