### PR TITLE
squid:MissingDeprecatedCheck - Deprecated elements should have both t…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/config/ApplicationConfiguration.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/config/ApplicationConfiguration.java
@@ -36,6 +36,7 @@ public class ApplicationConfiguration implements Configuration {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected ApplicationConfiguration() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/controller/DefaultControllerNotFoundHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/controller/DefaultControllerNotFoundHandler.java
@@ -44,6 +44,7 @@ public class DefaultControllerNotFoundHandler implements ControllerNotFoundHandl
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultControllerNotFoundHandler() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/controller/DefaultInvalidInputHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/controller/DefaultInvalidInputHandler.java
@@ -21,6 +21,7 @@ public class DefaultInvalidInputHandler implements InvalidInputHandler {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultInvalidInputHandler() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/BigDecimalConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/BigDecimalConverter.java
@@ -50,6 +50,7 @@ public class BigDecimalConverter implements Converter<BigDecimal> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected BigDecimalConverter() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/CalendarConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/CalendarConverter.java
@@ -48,6 +48,7 @@ public class CalendarConverter implements Converter<Calendar> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected CalendarConverter() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/DateConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/DateConverter.java
@@ -47,6 +47,7 @@ public class DateConverter implements Converter<Date> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DateConverter() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/DoubleConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/DoubleConverter.java
@@ -50,6 +50,7 @@ public class DoubleConverter implements Converter<Double> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DoubleConverter() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/FloatConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/FloatConverter.java
@@ -50,6 +50,7 @@ public class FloatConverter implements Converter<Float> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected FloatConverter() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/PrimitiveBooleanConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/PrimitiveBooleanConverter.java
@@ -44,6 +44,7 @@ public class PrimitiveBooleanConverter implements Converter<Boolean> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected PrimitiveBooleanConverter() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/PrimitiveDoubleConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/PrimitiveDoubleConverter.java
@@ -53,7 +53,7 @@ public class PrimitiveDoubleConverter implements Converter<Double> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
-
+	@Deprecated
 	public PrimitiveDoubleConverter() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/PrimitiveFloatConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/converter/PrimitiveFloatConverter.java
@@ -53,6 +53,7 @@ public class PrimitiveFloatConverter implements Converter<Float> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected PrimitiveFloatConverter() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultConverters.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultConverters.java
@@ -58,6 +58,7 @@ public class DefaultConverters implements Converters {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultConverters() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultExceptionMapper.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultExceptionMapper.java
@@ -51,6 +51,7 @@ public class DefaultExceptionMapper implements ExceptionMapper {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultExceptionMapper() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultInterceptorHandlerFactory.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultInterceptorHandlerFactory.java
@@ -50,6 +50,7 @@ public class DefaultInterceptorHandlerFactory implements InterceptorHandlerFacto
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultInterceptorHandlerFactory() {
 		this(null, null, null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultInterceptorStack.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultInterceptorStack.java
@@ -55,6 +55,7 @@ public class DefaultInterceptorStack implements InterceptorStack {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultInterceptorStack() {
 		this(null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultResult.java
@@ -58,6 +58,7 @@ public class DefaultResult extends AbstractResult {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultResult() {
 		this(null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultStaticContentHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/DefaultStaticContentHandler.java
@@ -49,6 +49,7 @@ public class DefaultStaticContentHandler implements StaticContentHandler {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultStaticContentHandler() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/InterceptorStackHandlersCache.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/InterceptorStackHandlersCache.java
@@ -40,6 +40,7 @@ public class InterceptorStackHandlersCache {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected InterceptorStackHandlersCache() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/JstlLocalization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/JstlLocalization.java
@@ -54,6 +54,7 @@ public class JstlLocalization {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected JstlLocalization() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/MethodInfo.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/MethodInfo.java
@@ -45,6 +45,7 @@ public class MethodInfo {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected MethodInfo() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
@@ -62,6 +62,7 @@ public class DefaultEnvironment implements Environment {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultEnvironment() {
 		this((ServletContext) null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/EnvironmentPropertyProducer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/EnvironmentPropertyProducer.java
@@ -45,6 +45,7 @@ public class EnvironmentPropertyProducer {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected EnvironmentPropertyProducer() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/DefaultControllerTranslator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/DefaultControllerTranslator.java
@@ -44,6 +44,7 @@ public class DefaultControllerTranslator implements UrlToControllerTranslator {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultControllerTranslator() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/DefaultFormatResolver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/DefaultFormatResolver.java
@@ -38,6 +38,7 @@ public class DefaultFormatResolver implements FormatResolver {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultFormatResolver() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/EncodingHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/EncodingHandler.java
@@ -50,6 +50,7 @@ public class EncodingHandler {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected EncodingHandler() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/IogiParametersProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/IogiParametersProvider.java
@@ -52,6 +52,7 @@ public class IogiParametersProvider implements ParametersProvider {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected IogiParametersProvider() {
 		this(null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorDependencyProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorDependencyProvider.java
@@ -39,6 +39,7 @@ public class VRaptorDependencyProvider implements DependencyProvider {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected VRaptorDependencyProvider() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorInstantiator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorInstantiator.java
@@ -66,6 +66,7 @@ public class VRaptorInstantiator implements InstantiatorWithErrors, Instantiator
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected VRaptorInstantiator() {
 		this(null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorParameterNamesProvider.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/iogi/VRaptorParameterNamesProvider.java
@@ -42,6 +42,7 @@ public class VRaptorParameterNamesProvider implements br.com.caelum.iogi.spi.Par
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected VRaptorParameterNamesProvider() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouter.java
@@ -76,6 +76,7 @@ public class DefaultRouter implements Router {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultRouter() {
 		this(null, null, null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultTypeFinder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultTypeFinder.java
@@ -43,6 +43,7 @@ public class DefaultTypeFinder implements TypeFinder {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultTypeFinder() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/JavaEvaluator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/JavaEvaluator.java
@@ -42,6 +42,7 @@ public class JavaEvaluator implements Evaluator {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected JavaEvaluator() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/PathAnnotationRoutesParser.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/PathAnnotationRoutesParser.java
@@ -77,6 +77,7 @@ public class PathAnnotationRoutesParser implements RoutesParser {
 	 * @deprecated CDI eyes only
 	 */
 
+	@Deprecated
 	protected PathAnnotationRoutesParser() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/AcceptsNeedReturnBooleanValidationRule.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/AcceptsNeedReturnBooleanValidationRule.java
@@ -34,6 +34,7 @@ public class AcceptsNeedReturnBooleanValidationRule implements ValidationRule {
 	/** 
 	 * @deprecated CDI eyes only 
 	 */
+	@Deprecated
 	protected AcceptsNeedReturnBooleanValidationRule() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/CustomAcceptsExecutor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/CustomAcceptsExecutor.java
@@ -39,6 +39,7 @@ public class CustomAcceptsExecutor {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected CustomAcceptsExecutor() {
 		this(null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/CustomAcceptsVerifier.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/CustomAcceptsVerifier.java
@@ -38,6 +38,7 @@ public class CustomAcceptsVerifier {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected CustomAcceptsVerifier() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/CustomAndInternalAcceptsValidationRule.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/CustomAndInternalAcceptsValidationRule.java
@@ -35,6 +35,7 @@ public class CustomAndInternalAcceptsValidationRule implements ValidationRule {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected CustomAndInternalAcceptsValidationRule() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DefaultSimpleInterceptorStack.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/DefaultSimpleInterceptorStack.java
@@ -32,6 +32,7 @@ public class DefaultSimpleInterceptorStack implements SimpleInterceptorStack {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultSimpleInterceptorStack() {
 		this(null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/ExceptionHandlerInterceptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/ExceptionHandlerInterceptor.java
@@ -53,6 +53,7 @@ public class ExceptionHandlerInterceptor implements Interceptor {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected ExceptionHandlerInterceptor() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/FlashInterceptor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/FlashInterceptor.java
@@ -52,6 +52,7 @@ public class FlashInterceptor implements Interceptor {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected FlashInterceptor() {
 		this(null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/InterceptorAcceptsExecutor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/InterceptorAcceptsExecutor.java
@@ -31,6 +31,7 @@ public class InterceptorAcceptsExecutor {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected InterceptorAcceptsExecutor() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/InterceptorExecutor.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/InterceptorExecutor.java
@@ -42,6 +42,7 @@ public class InterceptorExecutor {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected InterceptorExecutor() {
 		this(null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/InterceptorMethodParametersResolver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/InterceptorMethodParametersResolver.java
@@ -32,6 +32,7 @@ public class InterceptorMethodParametersResolver {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected InterceptorMethodParametersResolver() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/NoInterceptMethodsValidationRule.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/NoInterceptMethodsValidationRule.java
@@ -37,6 +37,7 @@ public class NoInterceptMethodsValidationRule implements ValidationRule {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected NoInterceptMethodsValidationRule() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/NoStackParamValidationRule.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/NoStackParamValidationRule.java
@@ -41,6 +41,7 @@ public class NoStackParamValidationRule implements ValidationRule {
 	/** 
 	 * @deprecated CDI eyes only 
 	 */
+	@Deprecated
 	protected NoStackParamValidationRule() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/StepInvoker.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/interceptor/StepInvoker.java
@@ -39,6 +39,7 @@ public class StepInvoker {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected StepInvoker() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/ControllerHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/ControllerHandler.java
@@ -49,6 +49,7 @@ public class ControllerHandler{
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected ControllerHandler() {
 		this(null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/ConverterHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/ConverterHandler.java
@@ -37,6 +37,7 @@ public class ConverterHandler{
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected ConverterHandler() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/InterceptorStereotypeHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/InterceptorStereotypeHandler.java
@@ -43,6 +43,7 @@ public class InterceptorStereotypeHandler {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected InterceptorStereotypeHandler() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIBasedContainer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/ioc/cdi/CDIBasedContainer.java
@@ -39,6 +39,7 @@ public class CDIBasedContainer implements Container {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected CDIBasedContainer(){
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/DeserializingObserver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/DeserializingObserver.java
@@ -57,6 +57,7 @@ public class DeserializingObserver {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DeserializingObserver() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ForwardToDefaultView.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ForwardToDefaultView.java
@@ -48,6 +48,7 @@ public class ForwardToDefaultView {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected ForwardToDefaultView() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/InstantiateObserver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/InstantiateObserver.java
@@ -50,6 +50,7 @@ public class InstantiateObserver {
 	/**
 	 *  @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected InstantiateObserver(){
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/OutjectResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/OutjectResult.java
@@ -48,6 +48,7 @@ public class OutjectResult {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected OutjectResult() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParameterIncluder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParameterIncluder.java
@@ -41,6 +41,7 @@ public class ParameterIncluder {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected ParameterIncluder() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParametersInstantiator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/ParametersInstantiator.java
@@ -65,6 +65,7 @@ public class ParametersInstantiator {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected ParametersInstantiator() {
 		this(null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/RequestHandlerObserver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/RequestHandlerObserver.java
@@ -65,6 +65,7 @@ public class RequestHandlerObserver {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected RequestHandlerObserver() {
 		this(null, null, null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/download/DownloadView.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/download/DownloadView.java
@@ -37,6 +37,7 @@ public class DownloadView implements View {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DownloadView() {
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/UploadedFileConverter.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/UploadedFileConverter.java
@@ -37,6 +37,7 @@ public class UploadedFileConverter implements Converter<UploadedFile> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected UploadedFileConverter() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/DefaultRepresentationResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/DefaultRepresentationResult.java
@@ -48,6 +48,7 @@ public class DefaultRepresentationResult implements RepresentationResult {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultRepresentationResult() {
 		this(null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/DeserializesHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/DeserializesHandler.java
@@ -38,6 +38,7 @@ public class DeserializesHandler{
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DeserializesHandler() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/FormDeserializer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/FormDeserializer.java
@@ -36,6 +36,7 @@ public class FormDeserializer implements Deserializer {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected FormDeserializer() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/HTMLSerialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/HTMLSerialization.java
@@ -37,6 +37,7 @@ public class HTMLSerialization implements Serialization {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected HTMLSerialization() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/I18nMessageSerialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/I18nMessageSerialization.java
@@ -40,6 +40,7 @@ public class I18nMessageSerialization implements View {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected I18nMessageSerialization() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonDeserialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonDeserialization.java
@@ -71,6 +71,7 @@ public class GsonDeserialization implements Deserializer {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected GsonDeserialization() {
 		this(null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonJSONPSerialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonJSONPSerialization.java
@@ -47,6 +47,7 @@ public class GsonJSONPSerialization implements JSONPSerialization {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected GsonJSONPSerialization() {
 		this(null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonJSONSerialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonJSONSerialization.java
@@ -49,6 +49,7 @@ public class GsonJSONSerialization implements JSONSerialization {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected GsonJSONSerialization() {
 		this(null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamBuilderImpl.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamBuilderImpl.java
@@ -50,6 +50,7 @@ public class XStreamBuilderImpl implements XStreamBuilder {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected XStreamBuilderImpl() {
 		this(null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamConverters.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamConverters.java
@@ -45,6 +45,7 @@ public class XStreamConverters {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected XStreamConverters() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamXMLDeserializer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamXMLDeserializer.java
@@ -47,6 +47,7 @@ public class XStreamXMLDeserializer implements Deserializer {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected XStreamXMLDeserializer() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamXMLSerialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/xstream/XStreamXMLSerialization.java
@@ -50,6 +50,7 @@ public class XStreamXMLSerialization implements XMLSerialization {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected XStreamXMLSerialization() {
 		this(null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/DefaultValidator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/DefaultValidator.java
@@ -64,6 +64,7 @@ public class DefaultValidator extends AbstractValidator {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultValidator() {
 		this(null, null, null, null, null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/MessagesProducer.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/MessagesProducer.java
@@ -18,6 +18,7 @@ public class MessagesProducer {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected MessagesProducer() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/ReplicatorOutjector.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/ReplicatorOutjector.java
@@ -36,6 +36,7 @@ public class ReplicatorOutjector implements Outjector {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected ReplicatorOutjector() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MessageInterpolatorFactory.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MessageInterpolatorFactory.java
@@ -41,6 +41,7 @@ public class MessageInterpolatorFactory{
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected MessageInterpolatorFactory() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MethodValidator.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/beanvalidation/MethodValidator.java
@@ -63,6 +63,7 @@ public class MethodValidator {
 	/**
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected MethodValidator() {
 		this(null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultAcceptHeaderToFormat.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultAcceptHeaderToFormat.java
@@ -54,6 +54,7 @@ public class DefaultAcceptHeaderToFormat implements AcceptHeaderToFormat {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultAcceptHeaderToFormat() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultHttpResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultHttpResult.java
@@ -44,6 +44,7 @@ public class DefaultHttpResult implements HttpResult {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultHttpResult() {
 		this(null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultLogicResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultLogicResult.java
@@ -71,6 +71,7 @@ public class DefaultLogicResult implements LogicResult {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultLogicResult() {
 		this(null, null, null, null, null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPageResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPageResult.java
@@ -59,6 +59,7 @@ public class DefaultPageResult implements PageResult {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultPageResult() {
 		this(null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultPathResolver.java
@@ -43,6 +43,7 @@ public class DefaultPathResolver implements PathResolver {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultPathResolver() {
 		this(null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultRefererResult.java
@@ -56,6 +56,7 @@ public class DefaultRefererResult implements RefererResult {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultRefererResult() {
 		this(null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultStatus.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultStatus.java
@@ -56,6 +56,7 @@ public class DefaultStatus implements Status {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultStatus() {
 		this(null, null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultValidationViewsFactory.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/DefaultValidationViewsFactory.java
@@ -61,6 +61,7 @@ public class DefaultValidationViewsFactory implements ValidationViewsFactory {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected DefaultValidationViewsFactory() {
 		this(null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/LinkToHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/LinkToHandler.java
@@ -85,6 +85,7 @@ public class LinkToHandler extends ForwardingMap<Class<?>, Object> {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected LinkToHandler() {
 		this(null, null, null, null);
 	}

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/SessionFlashScope.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/SessionFlashScope.java
@@ -36,6 +36,7 @@ public class SessionFlashScope implements FlashScope {
 	/** 
 	 * @deprecated CDI eyes only
 	 */
+	@Deprecated
 	protected SessionFlashScope() {
 		this(null);
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:MissingDeprecatedCheck

Please let me know if you have any questions.

M-Ezzat