### PR TITLE
squid:S2326,squid:S2293 - Unused type parameters should be removed, T…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/CacheStoreFactory.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/CacheStoreFactory.java
@@ -42,7 +42,7 @@ public class CacheStoreFactory {
 	@Produces
 	@Default
 	public <K, V> CacheStore<K, V> buildDefaultCache() {
-		return new DefaultCacheStore<K, V>();
+		return new DefaultCacheStore<>();
 	}
 
 	@Produces
@@ -56,7 +56,7 @@ public class CacheStoreFactory {
 		Cache<K, V> guavaCache = CacheBuilder.newBuilder()
 			.maximumSize(capacity)
 			.build();
-		return new GuavaCacheWrapper<K,V>(guavaCache);
+		return new GuavaCacheWrapper<>(guavaCache);
 	}
 	
 	public static class  GuavaCacheWrapper<K,V> implements CacheStore<K, V>{

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/core/Try.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/core/Try.java
@@ -51,7 +51,7 @@ public abstract class Try<T> {
 		}
 	}
 
-	public static class Failed<T> extends Try {
+	public static class Failed extends Try {
 		private final Exception e;
 
 		private Failed(Exception e) {

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/JSONSerialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/JSONSerialization.java
@@ -34,7 +34,7 @@ public interface JSONSerialization extends Serialization {
 	 * Exclude the root alias from serialization.
 	 * @since 3.1.2
 	 */
-	<T> NoRootSerialization withoutRoot();
+	NoRootSerialization withoutRoot();
 	
 	JSONSerialization indented();
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonJSONSerialization.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/serialization/gson/GsonJSONSerialization.java
@@ -98,7 +98,7 @@ public class GsonJSONSerialization implements JSONSerialization {
 	 * You can override this method for configuring Driver before serialization
 	 */
 	@Override
-	public <T> NoRootSerialization withoutRoot() {
+	public NoRootSerialization withoutRoot() {
 		builder.setWithoutRoot(true);
 		return this;
 	}

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MethodValidatorTest.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/validator/MethodValidatorTest.java
@@ -119,7 +119,7 @@ public class MethodValidatorTest {
 	}
 
 	private MethodValidator getMethodValidator() {
-		return new MethodValidator(new MockInstanceImpl<Locale>(new Locale("pt", "br")), interpolator, validatorFactory.getValidator());
+		return new MethodValidator(new MockInstanceImpl<>(new Locale("pt", "br")), interpolator, validatorFactory.getValidator());
 	}
 	
 	public class Example {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2326 - Unused type parameters should be removed
squid:S2293 - The diamond operator ("<>") should be used

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2326
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2293
Please let me know if you have any questions.

M-Ezzat