### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/download/DownloadBuilder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/download/DownloadBuilder.java
@@ -1,5 +1,7 @@
 package br.com.caelum.vraptor.observer.download;
 
+import com.thoughtworks.xstream.InitializationException;
+
 import static com.google.common.base.Objects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
@@ -19,6 +21,10 @@ import javax.enterprise.inject.Vetoed;
  */
 @Vetoed
 public final class DownloadBuilder {
+
+	private DownloadBuilder () {
+		throw new InitializationException("Not allowed to initialize");
+	}
 
 	/**
 	 * Creates an instance for build a {@link FileDownload}.<br>

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/proxy/CDIProxies.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/proxy/CDIProxies.java
@@ -17,6 +17,7 @@ package br.com.caelum.vraptor.proxy;
 
 import javax.enterprise.inject.Vetoed;
 
+import com.thoughtworks.xstream.InitializationException;
 import org.jboss.weld.bean.proxy.ProxyObject;
 import org.jboss.weld.interceptor.util.proxy.TargetInstanceProxy;
 
@@ -30,6 +31,9 @@ import org.jboss.weld.interceptor.util.proxy.TargetInstanceProxy;
  */
 @Vetoed
 public final class CDIProxies {
+	private CDIProxies(){
+		throw new InitializationException("Not allowed to initialize");
+	}
 
 	public static boolean isCDIProxy(Class<?> type) {
 		return ProxyObject.class.isAssignableFrom(type);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/util/StringUtils.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/util/StringUtils.java
@@ -17,6 +17,8 @@
 
 package br.com.caelum.vraptor.util;
 
+import com.thoughtworks.xstream.InitializationException;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,8 +30,11 @@ import javax.enterprise.inject.Vetoed;
  * @author Lucas Cavalcanti
  */
 @Vetoed
-public class StringUtils {
+public final class StringUtils {
 
+	private StringUtils(){
+		throw new InitializationException("Not allowed to initialize");
+	}
 	public static String decapitalize(String name) {
 		if (name.length() == 1) {
 			return name.toLowerCase();

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/Results.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/Results.java
@@ -24,6 +24,7 @@ import br.com.caelum.vraptor.serialization.JSONPSerialization;
 import br.com.caelum.vraptor.serialization.JSONSerialization;
 import br.com.caelum.vraptor.serialization.RepresentationResult;
 import br.com.caelum.vraptor.serialization.XMLSerialization;
+import com.thoughtworks.xstream.InitializationException;
 
 /**
  * Some common results for most web based logics.
@@ -31,8 +32,11 @@ import br.com.caelum.vraptor.serialization.XMLSerialization;
  * @author Guilherme Silveira
  */
 @Vetoed
-public class Results {
+public final class Results {
 
+	private Results(){
+		throw new InitializationException("Not allowed to initialize");
+	}
 	/**
 	 * Offers server side forward and include for web pages.<br>
 	 * Should be used only with end results (not logics), otherwise you might

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/VRaptorMatchers.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/VRaptorMatchers.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.ResourceBundle;
 
+import com.thoughtworks.xstream.InitializationException;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -32,7 +33,11 @@ import br.com.caelum.vraptor.converter.ConversionMessage;
 import br.com.caelum.vraptor.http.route.Route;
 import br.com.caelum.vraptor.validator.Message;
 
-public class VRaptorMatchers {
+public final class VRaptorMatchers {
+	private VRaptorMatchers(){
+		throw new InitializationException("Not allowed to initialize");
+	}
+
 	public static Matcher<Collection<?>> hasOneCopyOf(final Object item) {
 		return new TypeSafeMatcher<Collection<?>>(){
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/VRaptorMatchers.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/interceptor/VRaptorMatchers.java
@@ -18,6 +18,7 @@ package br.com.caelum.vraptor.interceptor;
 
 import java.lang.reflect.Method;
 
+import com.thoughtworks.xstream.InitializationException;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -33,8 +34,10 @@ import br.com.caelum.vraptor.validator.SimpleMessage;
  *
  * @author Guilherme Silveira
  */
-public class VRaptorMatchers {
-
+public final class VRaptorMatchers {
+	private VRaptorMatchers(){
+		throw new InitializationException("Not allowed to initialize");
+	}
 	public static TypeSafeMatcher<ControllerMethod> controllerMethod(final Method method) {
 		return new TypeSafeMatcher<ControllerMethod>() {
 

--- a/vraptor-core/src/test/java/br/com/caelum/vraptor/ioc/fixture/HasConstructor.java
+++ b/vraptor-core/src/test/java/br/com/caelum/vraptor/ioc/fixture/HasConstructor.java
@@ -16,8 +16,12 @@
 package br.com.caelum.vraptor.ioc.fixture;
 
 import br.com.caelum.vraptor.Result;
+import com.thoughtworks.xstream.InitializationException;
 
-public class HasConstructor {
+public final class HasConstructor {
+	private HasConstructor(){
+		throw new InitializationException("Not allowed to initialize");
+	}
 
 	public HasConstructor(Result result) {
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat