### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/Path.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/Path.java
@@ -34,6 +34,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Path {
 
+	public static final int LOWEST = Integer.MAX_VALUE;
+	public static final int LOW = Integer.MAX_VALUE/4*3;
+	public static final int DEFAULT = Integer.MAX_VALUE/2;
+	public static final int HIGH = Integer.MAX_VALUE/4;
+	public static final int HIGHEST = 0;
+
 	/**
 	 * All paths that will be mapped to an annotated Controller method. The path value also can be
 	 * configured in class level and using {@link Get}, {@link Post}, {@link Trace} and {@link Delete}
@@ -56,11 +62,5 @@ public @interface Path {
 	 *
 	 */
 	int priority() default DEFAULT;
-
-	public static final int LOWEST = Integer.MAX_VALUE;
-	public static final int LOW = Integer.MAX_VALUE/4*3;
-	public static final int DEFAULT = Integer.MAX_VALUE/2;
-	public static final int HIGH = Integer.MAX_VALUE/4;
-	public static final int HIGHEST = 0;
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/environment/DefaultEnvironment.java
@@ -70,18 +70,18 @@ public class DefaultEnvironment implements Environment {
 	public DefaultEnvironment(ServletContext context) {
 		this.context = context;
 	}
-	
-	@PostConstruct
-	protected void setup() {
-		loadProperties();
-	}
-	
+
 	public DefaultEnvironment(EnvironmentType environmentType) {
 		this((ServletContext) null);
 		this.environmentType = environmentType;
 		loadProperties();
 	}
-	
+
+	@PostConstruct
+	protected void setup() {
+		loadProperties();
+	}
+
 	private void loadProperties() {
 		properties = new Properties();
 		loadAndPut(BASE_ENVIRONMENT_FILE);

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/RouteNotFoundException.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/RouteNotFoundException.java
@@ -29,10 +29,10 @@ import br.com.caelum.vraptor.VRaptorException;
 @Vetoed
 public class RouteNotFoundException extends VRaptorException {
 
+	private static final long serialVersionUID = 606801838930057251L;
+
 	public RouteNotFoundException(String msg) {
 		super(msg);
 	}
-
-	private static final long serialVersionUID = 606801838930057251L;
 
 }

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/view/LinkToHandler.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/view/LinkToHandler.java
@@ -82,6 +82,8 @@ public class LinkToHandler extends ForwardingMap<Class<?>, Object> {
 
 	private final ConcurrentMap<Class<?>, Class<?>> interfaces = new ConcurrentHashMap<>();
 
+	private final Lock lock = new ReentrantLock();
+
 	/** 
 	 * @deprecated CDI eyes only
 	 */
@@ -106,8 +108,6 @@ public class LinkToHandler extends ForwardingMap<Class<?>, Object> {
 	protected Map<Class<?>, Object> delegate() {
 		return Collections.emptyMap();
 	}
-
-	private final Lock lock = new ReentrantLock();
 
 	@Override
 	public Object get(Object key) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat