### PR TITLE
squid:S1192, squid:S2293 - String literals should not be duplicated, …

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/CacheStoreFactory.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/cache/CacheStoreFactory.java
@@ -42,7 +42,7 @@ public class CacheStoreFactory {
 	@Produces
 	@Default
 	public <K, V> CacheStore<K, V> buildDefaultCache() {
-		return new DefaultCacheStore<K, V>();
+		return new DefaultCacheStore<>();
 	}
 
 	@Produces
@@ -56,7 +56,7 @@ public class CacheStoreFactory {
 		Cache<K, V> guavaCache = CacheBuilder.newBuilder()
 			.maximumSize(capacity)
 			.build();
-		return new GuavaCacheWrapper<K,V>(guavaCache);
+		return new GuavaCacheWrapper<>(guavaCache);
 	}
 	
 	public static class  GuavaCacheWrapper<K,V> implements CacheStore<K, V>{

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/CommonsUploadedFile.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/CommonsUploadedFile.java
@@ -42,6 +42,7 @@ import org.apache.commons.io.IOUtils;
  */
 @Vetoed
 public class CommonsUploadedFile implements UploadedFile {
+	private static final String TARGET_CANNOT_BE_NULL = "Target can't be null";
 
 	private final FileItem delegate;
 
@@ -71,7 +72,7 @@ public class CommonsUploadedFile implements UploadedFile {
 
 	@Override
 	public void writeTo(File target) throws IOException {
-		requireNonNull(target, "Target can't be null");
+		requireNonNull(target, TARGET_CANNOT_BE_NULL);
 
 		try {
 			delegate.write(target);
@@ -85,13 +86,13 @@ public class CommonsUploadedFile implements UploadedFile {
 
 	@Override
 	public void writeTo(Path target, CopyOption... options) throws IOException {
-		requireNonNull(target, "Target can't be null");
+		requireNonNull(target, TARGET_CANNOT_BE_NULL);
 		writeTo(target.toFile());
 	}
 
 	@Override
 	public void writeTo(OutputStream target) throws IOException {
-		requireNonNull(target, "Target can't be null");
+		requireNonNull(target, TARGET_CANNOT_BE_NULL);
 		IOUtils.copy(getFile(), target);
 	}
 

--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/DefaultUploadedFile.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/observer/upload/DefaultUploadedFile.java
@@ -35,7 +35,8 @@ import org.apache.commons.io.IOUtils;
  */
 @Vetoed
 public class DefaultUploadedFile implements UploadedFile {
-	
+	private static final String TARGET_CANNOT_BE_NULL = "Target can't be null";
+
 	private final String contentType;
 	private final String fileName;
 	private final InputStream content;
@@ -70,13 +71,13 @@ public class DefaultUploadedFile implements UploadedFile {
 
 	@Override
 	public void writeTo(File target) throws IOException {
-		requireNonNull(target, "Target can't be null");
+		requireNonNull(target, TARGET_CANNOT_BE_NULL);
 		writeTo(target.toPath());
 	}
 
 	@Override
 	public void writeTo(Path target, CopyOption... options) throws IOException {
-		requireNonNull(target, "Target can't be null");
+		requireNonNull(target, TARGET_CANNOT_BE_NULL);
 		try (InputStream in = getFile()) {
 			copy(in, target, options);
 		}
@@ -84,7 +85,7 @@ public class DefaultUploadedFile implements UploadedFile {
 
 	@Override
 	public void writeTo(OutputStream target) throws IOException {
-		requireNonNull(target, "Target can't be null");
+		requireNonNull(target, TARGET_CANNOT_BE_NULL);
 		IOUtils.copy(getFile(), target);
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1192 - String literals should not be duplicated
squid:S2293 - The diamond operator ("<>") should be used

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1192
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2293

Please let me know if you have any questions.

M-Ezzat