### PR TITLE
'Messages' not serializable error when trying to redirect() using session replication

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/Messages.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/validator/Messages.java
@@ -17,6 +17,7 @@ package br.com.caelum.vraptor.validator;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,7 +41,9 @@ import org.slf4j.Logger;
  * @author Otávio S Garcia
  */
 @Vetoed
-public class Messages {
+public class Messages implements Serializable {
+
+	private static final long serialVersionUID = 728589528391504120L;
 
 	private final static Logger log = getLogger(Messages.class);
 	


### PR DESCRIPTION
Tested with Wildfly using standalone-ha.xml to replicate the http session