### PR TITLE
Extract route strategy creation to protected method to allow extension

### DIFF
--- a/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouteBuilder.java
+++ b/vraptor-core/src/main/java/br/com/caelum/vraptor/http/route/DefaultRouteBuilder.java
@@ -185,10 +185,20 @@ public class DefaultRouteBuilder implements RouteBuilder {
 		addParametersInfo(method);
 		ControllerMethod controllerMethod = DefaultControllerMethod.instanceFor(type, method);
 		Parameter[] parameterNames = nameProvider.parametersFor(method);
-		this.strategy = new FixedMethodStrategy(originalUri, controllerMethod, this.supportedMethods, builder.build(), priority, parameterNames);
+		this.strategy = getRouteStrategy(controllerMethod, parameterNames);
 
 		logger.info(String.format("%-50s%s -> %10s", originalUri,
 				this.supportedMethods.isEmpty() ? "[ALL]" : this.supportedMethods, method));
+	}
+
+	/**
+	 * Override this method to change the default Route implementation
+	 * @param controllerMethod The ControllerMethod
+	 * @param parameterNames parameters of the method
+	 * @return Route representation
+	 */
+	protected Route getRouteStrategy(ControllerMethod controllerMethod, Parameter[] parameterNames) {
+		return new FixedMethodStrategy(originalUri, controllerMethod, this.supportedMethods, builder.build(), priority, parameterNames);
 	}
 
 	private void addParametersInfo(Method method) {


### PR DESCRIPTION

This PR creates a protected method in `DefaultRouteBuilder` to allow customization of the default Route implementation. This way, anyone who want to use a `Route` implementation instead of `FixedMethodStrategy` can only override this method.

### Changelog
- Extract route creation to a method.