### PR TITLE
Fix Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 sudo: false
 jdk:
-  - oraclejdk8
+  - openjdk8


### PR DESCRIPTION
Changes oraclejdk8 to openjdk8 due to license issues with the former.
That fix the Travis error below:

`The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .`